### PR TITLE
update readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -200,7 +200,7 @@ Alpha. Expect API breakages.
 
 Prerequisites:
 
-- Shared: Git, CMake, Ninja, C++ compiler, JDK 11+, $JAVA_HOME, Python 3
+- Shared: Git, CMake(>=3.11), Ninja, C++ compiler, JDK 11+, $JAVA_HOME, Python 3
 - Windows 10: Microsoft Visual C++ (MSVC), x64 Native Tools Command Prompt for VS
 - Ubuntu 20.04: `libxcomposite-dev libxrandr-dev libgl1-mesa-dev libxi-dev libxcursor-dev`
 


### PR DESCRIPTION
cmake <3.11 raises the error: Policy "CMP0072" is not known to this version of CMake.