### PR TITLE
More macOS titlebar changes

### DIFF
--- a/linux/java/WindowX11.java
+++ b/linux/java/WindowX11.java
@@ -72,7 +72,7 @@ public class WindowX11 extends Window {
     public Window setTitle(String title) {
         assert _onUIThread();
         try {
-            _nSetTitle(title == null ? new byte[0] : title.getBytes("UTF-8"));
+            _nSetTitle(title.getBytes("UTF-8"));
         } catch (UnsupportedEncodingException ignored) {}
         return this;
     }

--- a/macos/cc/WindowMac.mm
+++ b/macos/cc/WindowMac.mm
@@ -248,17 +248,13 @@ extern "C" JNIEXPORT void JNICALL Java_io_github_humbleui_jwm_WindowMac__1nSetCo
 extern "C" JNIEXPORT void JNICALL Java_io_github_humbleui_jwm_WindowMac__1nSetTitle
   (JNIEnv* env, jobject obj, jstring titleStr) {
     jwm::WindowMac* instance = reinterpret_cast<jwm::WindowMac*>(jwm::classes::Native::fromJava(env, obj));
-    if (env->IsSameObject(titleStr, nullptr)) {
-        [instance->fNSWindow setTitleVisibility:NSWindowTitleHidden];
-    } else {
-        jsize len = env->GetStringLength(titleStr);
-        const jchar* chars = env->GetStringCritical(titleStr, nullptr);
-        NSString* title = [[NSString alloc] initWithCharacters:chars length:len];
-        env->ReleaseStringCritical(titleStr, chars);
-        instance->fNSWindow.title = title;
-        [instance->fNSWindow setTitleVisibility:NSWindowTitleVisible];
-        [title release];
-    }
+    jsize len = env->GetStringLength(titleStr);
+    const jchar* chars = env->GetStringCritical(titleStr, nullptr);
+    NSString* title = [[NSString alloc] initWithCharacters:chars length:len];
+    env->ReleaseStringCritical(titleStr, chars);
+    instance->fNSWindow.title = title;
+    [instance->fNSWindow setTitleVisibility:NSWindowTitleVisible];
+    [title release];
 }
 
 #if __MAC_OS_X_VERSION_MAX_ALLOWED >= 110000
@@ -294,20 +290,6 @@ extern "C" JNIEXPORT void JNICALL Java_io_github_humbleui_jwm_WindowMac__1nSetIc
     app.applicationIconImage = image;
 
     [image release];
-}
-
-extern "C" JNIEXPORT void JNICALL Java_io_github_humbleui_jwm_WindowMac__1nSetTitlebarVisible
-        (JNIEnv* env, jobject obj, jboolean value) {
-    jwm::WindowMac* instance = reinterpret_cast<jwm::WindowMac*>(jwm::classes::Native::fromJava(env, obj));
-    NSWindow* nsWindow = instance->fNSWindow;
-
-    NSWindowStyleMask style = [nsWindow styleMask];
-    if (value) {
-        style |= NSWindowStyleMaskTitled;
-    } else {
-        style &= ~NSWindowStyleMaskTitled;
-    }
-    [nsWindow setStyleMask:style];
 }
 
 extern "C" JNIEXPORT void JNICALL Java_io_github_humbleui_jwm_WindowMac__1nSetFullSizeContentView

--- a/macos/cc/WindowMac.mm
+++ b/macos/cc/WindowMac.mm
@@ -386,6 +386,19 @@ extern "C" JNIEXPORT void JNICALL Java_io_github_humbleui_jwm_WindowMac__1nSetTr
     }
 }
 
+extern "C" JNIEXPORT void JNICALL Java_io_github_humbleui_jwm_WindowMac__1nSetTrafficLightsVisible
+        (JNIEnv* env, jobject obj, jboolean value) {
+    jwm::WindowMac* instance = reinterpret_cast<jwm::WindowMac*>(jwm::classes::Native::fromJava(env, obj));
+    NSWindow* nsWindow = instance->fNSWindow;
+
+    NSButton *close = [nsWindow standardWindowButton:NSWindowCloseButton];
+    if (close != nullptr) close.hidden = !value;
+    NSButton *miniaturize = [nsWindow standardWindowButton:NSWindowMiniaturizeButton];
+    if (miniaturize != nullptr) miniaturize.hidden = !value;
+    NSButton *zoom = [nsWindow standardWindowButton:NSWindowZoomButton];
+    if (zoom != nullptr) zoom.hidden = !value;
+}
+
 extern "C" JNIEXPORT void JNICALL Java_io_github_humbleui_jwm_WindowMac__1nSetMouseCursor
   (JNIEnv* env, jobject obj, jint cursorIdx) {
     jwm::WindowMac* instance = reinterpret_cast<jwm::WindowMac*>(jwm::classes::Native::fromJava(env, obj));

--- a/macos/cc/WindowMac.mm
+++ b/macos/cc/WindowMac.mm
@@ -257,6 +257,12 @@ extern "C" JNIEXPORT void JNICALL Java_io_github_humbleui_jwm_WindowMac__1nSetTi
     [title release];
 }
 
+extern "C" JNIEXPORT void JNICALL Java_io_github_humbleui_jwm_WindowMac__1nSetTitleVisible
+  (JNIEnv* env, jobject obj, jboolean value) {
+    jwm::WindowMac* instance = reinterpret_cast<jwm::WindowMac*>(jwm::classes::Native::fromJava(env, obj));
+    [instance->fNSWindow setTitleVisibility:value ? NSWindowTitleVisible : NSWindowTitleHidden];
+}
+
 #if __MAC_OS_X_VERSION_MAX_ALLOWED >= 110000
 extern "C" JNIEXPORT void JNICALL Java_io_github_humbleui_jwm_WindowMac__1nSetSubtitle
   (JNIEnv* env, jobject obj, jstring subtitleStr) {

--- a/macos/java/WindowMac.java
+++ b/macos/java/WindowMac.java
@@ -67,6 +67,19 @@ public class WindowMac extends Window {
         return this;
     }
 
+    /**
+     * Hide the title from the title bar without changing the text content.
+     *
+     * @param isVisible visibility flag value
+     * @return this
+     */
+    @NotNull @Contract("-> this")
+    public Window setTitleVisible(boolean isVisible) {
+        assert _onUIThread();
+        _nSetTitleVisible(isVisible);
+        return this;
+    }
+
     @NotNull @Contract("-> this")
     public Window setSubtitle(@NotNull String title) {
         assert _onUIThread();
@@ -81,9 +94,19 @@ public class WindowMac extends Window {
         return this;
     }
 
+    /**
+     * <p>Shortcut for {@link #setTitleVisible(boolean)}, {@link #setFullSizeContentView(boolean)}</p>
+     *
+     * <p>TODO: Traffic light visibility</p>
+     *
+     * @param isVisible visibility flag value
+     * @return this
+     */
     @Override
     public Window setTitlebarVisible(boolean isVisible) {
-
+        assert _onUIThread();
+        setTitleVisible(isVisible);
+        setFullSizeContentView(!isVisible);
         return this;
     }
 

--- a/macos/java/WindowMac.java
+++ b/macos/java/WindowMac.java
@@ -107,6 +107,7 @@ public class WindowMac extends Window {
         assert _onUIThread();
         setTitleVisible(isVisible);
         setFullSizeContentView(!isVisible);
+        setTrafficLightsVisible(isVisible);
         return this;
     }
 
@@ -130,6 +131,13 @@ public class WindowMac extends Window {
     public WindowMac setTrafficLightPosition(int left, int top) {
         assert _onUIThread();
         _nSetTrafficLightPosition(left, top);
+        return this;
+    }
+
+    @NotNull @Contract("-> this")
+    public WindowMac setTrafficLightsVisible(boolean isVisible) {
+        assert _onUIThread();
+        _nSetTrafficLightsVisible(isVisible);
         return this;
     }
 
@@ -227,6 +235,7 @@ public class WindowMac extends Window {
     @ApiStatus.Internal public native void _nSetFullSizeContentView(boolean value);
     @ApiStatus.Internal public native void _nSetTitlebarStyle(int titlebarStyle);
     @ApiStatus.Internal public native void _nSetTrafficLightPosition(int left, int top);
+    @ApiStatus.Internal public native void _nSetTrafficLightsVisible(boolean value);
     @ApiStatus.Internal public native void _nSetVisible(boolean value);
     @ApiStatus.Internal public native Screen _nGetScreen();
     @ApiStatus.Internal public native void _nRequestFrame();

--- a/macos/java/WindowMac.java
+++ b/macos/java/WindowMac.java
@@ -83,9 +83,7 @@ public class WindowMac extends Window {
 
     @Override
     public Window setTitlebarVisible(boolean isVisible) {
-        assert _onUIThread();
-        _nSetTitlebarVisible(isVisible);
-        accept(new EventWindowResize(this));
+
         return this;
     }
 
@@ -200,9 +198,9 @@ public class WindowMac extends Window {
     @ApiStatus.Internal public native void _nSetWindowSize(int width, int height);
     @ApiStatus.Internal public native void _nSetContentSize(int width, int height);
     @ApiStatus.Internal public native void _nSetTitle(String title);
+    @ApiStatus.Internal public native void _nSetTitleVisible(boolean value);
     @ApiStatus.Internal public native void _nSetSubtitle(String title);
     @ApiStatus.Internal public native void _nSetIcon(String path);
-    @ApiStatus.Internal public native void _nSetTitlebarVisible(boolean value);
     @ApiStatus.Internal public native void _nSetFullSizeContentView(boolean value);
     @ApiStatus.Internal public native void _nSetTitlebarStyle(int titlebarStyle);
     @ApiStatus.Internal public native void _nSetTrafficLightPosition(int left, int top);

--- a/shared/java/Window.java
+++ b/shared/java/Window.java
@@ -191,7 +191,7 @@ public abstract class Window extends RefCounted implements Consumer<Event> {
      * @return          this
      */
     @NotNull @Contract("-> this")
-    public abstract Window setTitle(@Nullable String title);
+    public abstract Window setTitle(@NotNull String title);
 
     /**
      * <p>Set window icon from file on the disk.</p>

--- a/windows/java/WindowWin32.java
+++ b/windows/java/WindowWin32.java
@@ -64,7 +64,7 @@ public class WindowWin32 extends Window {
     @Override
     public Window setTitle(String title) {
         assert _onUIThread();
-        _nSetTitle(title == null ? "" : title);
+        _nSetTitle(title);
         return this;
     }
 


### PR DESCRIPTION
Makes the following changes:
 * Do not actually remove the title from the NSWindow, instead hide the title, traffic lights, and set full size content view
 * Add `WindowMac#setTitleVisible(boolean)`

Seeing an issue with setTitlebarVisible currently, and waiting on a way to hide traffic lights from #183 