### PR TITLE
X11: fix back/forward mouse buttons (closes #145)

### DIFF
--- a/linux/cc/MouseButtonX11.cc
+++ b/linux/cc/MouseButtonX11.cc
@@ -6,10 +6,14 @@ jwm::MouseButton jwm::MouseButtonX11::fromNative(uint32_t v) {
         case 1: return jwm::MouseButton::PRIMARY; 
         case 2: return jwm::MouseButton::MIDDLE;
         case 3: return jwm::MouseButton::SECONDARY;
-        case 4: return jwm::MouseButton::BACK;
-        case 5: return jwm::MouseButton::FORWARD;
+        case 8: return jwm::MouseButton::BACK;
+        case 9: return jwm::MouseButton::FORWARD;
     }
     return jwm::MouseButton::PRIMARY;
+}
+
+bool jwm::MouseButtonX11::isButton(uint32_t v) {
+    return v!=4 && v!=5; // mouse wheel buttons
 }
 
 int jwm::MouseButtonX11::fromNativeMask(unsigned v) {

--- a/linux/cc/MouseButtonX11.hh
+++ b/linux/cc/MouseButtonX11.hh
@@ -7,5 +7,6 @@ namespace jwm {
     namespace MouseButtonX11 {
         MouseButton fromNative(uint32_t v);
         int fromNativeMask(unsigned v);
+        bool isButton(uint32_t v);
     }
 }

--- a/linux/cc/WindowManagerX11.cc
+++ b/linux/cc/WindowManagerX11.cc
@@ -436,30 +436,36 @@ void WindowManagerX11::_processXEvent(XEvent& ev) {
         }
 
         case ButtonPress: { // mouse down
-            jwm::JNILocal<jobject> eventButton(
-                app.getJniEnv(),
-                EventMouseButton::make(
+            uint32_t button = ev.xbutton.button;
+            if (MouseButtonX11::isButton(button)) {
+                jwm::JNILocal<jobject> eventButton(
                     app.getJniEnv(),
-                    MouseButtonX11::fromNative(ev.xbutton.button),
-                    true,
-                    jwm::KeyX11::getModifiers()
-                )
-            );
-            myWindow->dispatch(eventButton.get());
+                    EventMouseButton::make(
+                        app.getJniEnv(),
+                        MouseButtonX11::fromNative(button),
+                        true,
+                        jwm::KeyX11::getModifiers()
+                    )
+                );
+                myWindow->dispatch(eventButton.get());
+            }
             break;
         }
 
-        case ButtonRelease: { // mouse down
-            jwm::JNILocal<jobject> eventButton(
-                app.getJniEnv(),
-                EventMouseButton::make(
+        case ButtonRelease: { // mouse up
+            uint32_t button = ev.xbutton.button;
+            if (MouseButtonX11::isButton(button)) {
+                jwm::JNILocal<jobject> eventButton(
                     app.getJniEnv(),
-                    MouseButtonX11::fromNative(ev.xbutton.button),
-                    false,
-                    jwm::KeyX11::getModifiers()
-                )
-            );
-            myWindow->dispatch(eventButton.get());
+                    EventMouseButton::make(
+                        app.getJniEnv(),
+                        MouseButtonX11::fromNative(button),
+                        false,
+                        jwm::KeyX11::getModifiers()
+                    )
+                );
+                myWindow->dispatch(eventButton.get());
+            }
             break;
         }
 


### PR DESCRIPTION
Use the correct (at least on my Linux) button numbers; also ignores 4 & 5, because those are mouse wheel up/down while JWM doesn't have those.