### PR TITLE
X11: Copy windows for iteration

### DIFF
--- a/linux/cc/WindowManagerX11.cc
+++ b/linux/cc/WindowManagerX11.cc
@@ -237,14 +237,19 @@ void WindowManagerX11::_processCallbacks() {
         }        
     }
     {
-        // process redraw requests
+        // copy window list in case one closes any other, invalidating some iterator in _nativeWindowToMy
+        std::vector<WindowX11*> copy;
         for (auto& p : _nativeWindowToMy) {
-            if (p.second->isRedrawRequested()) {
-                p.second->unsetRedrawRequest();
-                if (p.second->_layer) {
-                    p.second->_layer->makeCurrent();
+            copy.push_back(p.second);
+        }
+        // process redraw requests
+        for (auto p : copy) {
+            if (p->isRedrawRequested()) {
+                p->unsetRedrawRequest();
+                if (p->_layer) {
+                    p->_layer->makeCurrent();
                 }
-                p.second->dispatch(classes::EventFrame::kInstance);
+                p->dispatch(classes::EventFrame::kInstance);
             }
         }
     }


### PR DESCRIPTION
Otherwise the `EventFrame` dispatch may close the item the for loop currently holds an iterator of, ending up in undefined behavior and segfaults.

Alternative would be to keep a vector of windows to remove in `WindowManagerX11`, and removing them all inside `_processCallbacks` after they've been iterated through.