### PR TITLE
support windows visibility events

### DIFF
--- a/README.md
+++ b/README.md
@@ -150,7 +150,7 @@ Alpha. Expect API breakages.
 | EventWindowMinimize     | ✅   | ✅   | [#96](https://github.com/HumbleUI/JWM/issues/96)   |
 | EventWindowMaximize     | ✅   | ✅   | [#96](https://github.com/HumbleUI/JWM/issues/96)   |
 | EventWindowRestore      | ✅   | ✅   | [#96](https://github.com/HumbleUI/JWM/issues/96)   |
-| EventWindowVisible      | [#140](https://github.com/HumbleUI/JWM/issues/140) | [#140](https://github.com/HumbleUI/JWM/issues/140)   | [#140](https://github.com/HumbleUI/JWM/issues/140)   |
+| EventWindowVisible      | ✅   | [#140](https://github.com/HumbleUI/JWM/issues/140)   | [#140](https://github.com/HumbleUI/JWM/issues/140)   |
 | EventWindowScreenChange | [#117](https://github.com/HumbleUI/JWM/issues/117) | [#117](https://github.com/HumbleUI/JWM/issues/117) | [#117](https://github.com/HumbleUI/JWM/issues/117) |
 | EventWindowFocusIn      | ❌   | ❌   | ✅   |
 | EventWindowFocusOut     | ❌   | ❌   | ✅   |

--- a/shared/cc/impl/Library.cc
+++ b/shared/cc/impl/Library.cc
@@ -404,6 +404,30 @@ namespace jwm {
             }
         }
 
+        namespace EventWindowAppear {
+            jobject kInstance;
+
+            void onLoad(JNIEnv* env) {
+                JNILocal<jclass> cls(env, env->FindClass("io/github/humbleui/jwm/EventWindowAppear"));
+                Throwable::exceptionThrown(env);
+                jfieldID field = env->GetStaticFieldID(cls.get(), "INSTANCE", "Lio/github/humbleui/jwm/EventWindowAppear;");
+                jobject instance = env->GetStaticObjectField(cls.get(), field);
+                kInstance = env->NewGlobalRef(instance);
+            }
+        }
+
+        namespace EventWindowDisappear {
+            jobject kInstance;
+
+            void onLoad(JNIEnv* env) {
+                JNILocal<jclass> cls(env, env->FindClass("io/github/humbleui/jwm/EventWindowDisappear"));
+                Throwable::exceptionThrown(env);
+                jfieldID field = env->GetStaticFieldID(cls.get(), "INSTANCE", "Lio/github/humbleui/jwm/EventWindowDisappear;");
+                jobject instance = env->GetStaticObjectField(cls.get(), field);
+                kInstance = env->NewGlobalRef(instance);
+            }
+        }
+
         namespace EventWindowMove {
             jclass kCls;
             jmethodID kCtor;
@@ -571,6 +595,8 @@ extern "C" JNIEXPORT void JNICALL Java_io_github_humbleui_jwm_impl_Library__1nAf
     jwm::classes::EventWindowMinimize::onLoad(env);
     jwm::classes::EventWindowFocusIn::onLoad(env);
     jwm::classes::EventWindowFocusOut::onLoad(env);
+    jwm::classes::EventWindowAppear::onLoad(env);
+    jwm::classes::EventWindowDisappear::onLoad(env);
     jwm::classes::EventWindowMove::onLoad(env);
     jwm::classes::EventWindowResize::onLoad(env);
     jwm::classes::EventWindowRestore::onLoad(env);

--- a/shared/cc/impl/Library.hh
+++ b/shared/cc/impl/Library.hh
@@ -139,6 +139,14 @@ namespace jwm {
             extern jobject kInstance;
         }
 
+        namespace EventWindowAppear {
+            extern jobject kInstance;
+        }
+
+        namespace EventWindowDisappear {
+            extern jobject kInstance;
+        }
+
         namespace EventWindowMove {
             extern jclass kCls;
             extern jmethodID kCtor;

--- a/shared/java/EventWindowAppear.java
+++ b/shared/java/EventWindowAppear.java
@@ -1,0 +1,8 @@
+package io.github.humbleui.jwm;
+
+import lombok.Data;
+
+@Data
+public class EventWindowAppear implements Event {
+    public static final EventWindowAppear INSTANCE = new EventWindowAppear();
+}

--- a/shared/java/EventWindowDisappear.java
+++ b/shared/java/EventWindowDisappear.java
@@ -1,0 +1,8 @@
+package io.github.humbleui.jwm;
+
+import lombok.Data;
+
+@Data
+public class EventWindowDisappear implements Event {
+    public static final EventWindowDisappear INSTANCE = new EventWindowDisappear();
+}

--- a/windows/cc/WindowWin32.cc
+++ b/windows/cc/WindowWin32.cc
@@ -622,7 +622,14 @@ LRESULT jwm::WindowWin32::processEvent(UINT uMsg, WPARAM wParam, LPARAM lParam) 
                 return true;
             }
             break;
-
+        case WM_SHOWWINDOW:
+            JWM_VERBOSE("On window visibility change");
+            if (wParam == TRUE) {
+                dispatch(classes::EventWindowAppear::kInstance);
+            } else {
+                dispatch(classes::EventWindowDisappear::kInstance);
+            }
+            return 0;
         case WM_CLOSE:
             JWM_VERBOSE("Event close");
             dispatch(classes::EventWindowCloseRequest::kInstance);


### PR DESCRIPTION
I temporarily named event as `EventWindowAppear/Disappear`, but I think there would be better candidates.

Which do you think is better for visibility event name?

- EventWindowShow/Hidden
- EventWindowAppear/Disappear
- EventWindowVisibilityOn/Off
- EventWindowVisible/Invisible
- other

JWM notifies when window's visibility changes. In Windows, visibility is based mainly on WS_VISIBLE property and
updated by ShowWindow function and ShowOwnedPopups function.

see
- https://github.com/MicrosoftDocs/win32/blob/docs/desktop-src/winmsg/window-features.md#window-visibility
- https://docs.microsoft.com/en-us/windows/win32/winmsg/wm-showwindow