### PR TITLE
macOS: Menu bar issues

### DIFF
--- a/macos/cc/App.mm
+++ b/macos/cc/App.mm
@@ -4,6 +4,7 @@
 #include "impl/Library.hh"
 #include "MainView.hh"
 #include "Util.hh"
+#include "ApplicationDelegate.hh"
 
 // http://trac.wxwidgets.org/ticket/13557
 // here we subclass NSApplication, for the purpose of being able to override sendEvent
@@ -47,29 +48,11 @@ extern "C" JNIEXPORT void JNICALL Java_io_github_humbleui_jwm_App__1nInit
         return;
     }
 
-    NSAutoreleasePool* pool = [[NSAutoreleasePool alloc] init];
     [JWMNSApplication sharedApplication];
 
-    [NSApp setActivationPolicy:NSApplicationActivationPolicyRegular];
-
-    //Create the application menu.
-    NSMenu* menuBar=[[NSMenu alloc] initWithTitle:@"AMainMenu"];
-    [NSApp setMainMenu:menuBar];
-
-    NSMenuItem* item;
-    NSMenu* subMenu;
-
-    item=[[NSMenuItem alloc] initWithTitle:@"Apple" action:nil keyEquivalent:@""];
-    [menuBar addItem:item];
-    subMenu=[[NSMenu alloc] initWithTitle:@"Apple"];
-    [menuBar setSubmenu:subMenu forItem:item];
-    [item release];
-    item=[[NSMenuItem alloc] initWithTitle:@"Quit" action:@selector(terminate:) keyEquivalent:@"q"];
-    [subMenu addItem:item];
-    [item release];
-    [subMenu release];
-    [menuBar release];
-    [pool release];
+    ApplicationDelegate* delegate = [[ApplicationDelegate alloc] init];
+    [NSApp setDelegate:delegate];
+    [delegate release];
 
     jwm::initKeyTable();
     jwm::initCursorCache();

--- a/macos/cc/ApplicationDelegate.hh
+++ b/macos/cc/ApplicationDelegate.hh
@@ -1,0 +1,8 @@
+#pragma once
+#import <Cocoa/Cocoa.h>
+
+@interface ApplicationDelegate : NSObject<NSApplicationDelegate>
+
+- (void)applicationDidFinishLaunching:(NSNotification *)notification;
+
+@end

--- a/macos/cc/ApplicationDelegate.mm
+++ b/macos/cc/ApplicationDelegate.mm
@@ -1,0 +1,35 @@
+#include "ApplicationDelegate.hh"
+
+@implementation ApplicationDelegate {
+
+}
+
+- (void)applicationDidFinishLaunching:(NSNotification *)notification {
+    [NSApp setActivationPolicy:NSApplicationActivationPolicyRegular];
+    [NSApp activateIgnoringOtherApps:YES];
+
+    // Create application menu
+    NSAutoreleasePool *pool = [[NSAutoreleasePool alloc] init];
+    NSMenu *menuBar = [[NSMenu alloc] initWithTitle:@""];
+    [NSApp setMainMenu:menuBar];
+
+    NSMenuItem *item;
+    NSMenu *menu;
+
+    item = [[NSMenuItem alloc] initWithTitle:@"" action:nil keyEquivalent:@""];
+    [menuBar addItem:item];
+
+    menu = [[NSMenu alloc] initWithTitle:@"Apple"];
+    [menuBar setSubmenu:menu forItem:item];
+    [item release];
+
+    item = [[NSMenuItem alloc] initWithTitle:@"Quit" action:@selector(terminate:) keyEquivalent:@"q"];
+    [menu addItem:item];
+    [item release];
+
+    [menu release];
+    [menuBar release];
+    [pool release];
+}
+
+@end

--- a/macos/cc/WindowMac.mm
+++ b/macos/cc/WindowMac.mm
@@ -110,8 +110,6 @@ bool jwm::WindowMac::init() {
 
 void jwm::WindowMac::setVisible(bool value) {
     if (value && fDisplayLink == 0) {
-        [fNSWindow orderFront:nil];
-        [NSApp activateIgnoringOtherApps:YES];
         [fNSWindow makeKeyAndOrderFront:NSApp];
 
         CVDisplayLinkCreateWithActiveCGDisplays(&fDisplayLink);


### PR DESCRIPTION
When launching the example app, you are unable to interact with the menu bar (including the "apple menu").

The problematic call is `[NSApp activateIgnoringOtherApps:YES]` in `WindowMac#setVisible`. When called before the app has finished launching this fails. A solution proposed in [this SO answer](https://stackoverflow.com/questions/62739862/why-doesnt-activateignoringotherapps-enable-the-menu-bar) is to add an app delegate which calls `activateIgnoringOtherApps` on `applicationDidFinishLaunching` which does solve the issue.

The basic app menu does work after this change.