### PR TITLE
Workaround `-XstartOnMainThread` requirement on macos

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,7 +84,6 @@ Alpha. Expect API breakages.
 |-------------------|---------|-------|-----|
 | init              | ✅   | ✅   | ✅   |
 | makeWindow        | ✅   | [#121](https://github.com/HumbleUI/JWM/issues/121)   | ✅   |
-| start             | ✅   | ✅   | ✅   |
 | getScreens        | ✅   | ✅   | ✅   |
 | getPrimaryScreen  | ✅   | ✅   | ✅   |
 | runOnUIThread     | ✅   | ✅   | [#113](https://github.com/HumbleUI/JWM/issues/113) |

--- a/docs/Getting Started.md
+++ b/docs/Getting Started.md
@@ -25,12 +25,15 @@ E.g. for Maven it’ll look like this:
 Init JWM library:
 
 ```java
-App.init();
+App.init(() -> {
+    // Initialization here
+});
 ```
 
 Create a window:
 
 ```java
+// Inside App::init callback
 Window window = App.makeWindow();
 window.setTitle("Hello, world!");
 ```
@@ -87,12 +90,6 @@ On Windows and Linux, just run:
 
 ```sh
 java -cp jwm-0.3.1.jar:types-0.1.1.jar GettingStarted.java
-```
-
-On macOS, add `-XstartOnFirstThread` flag to `java`:
-
-```sh
-java -XstartOnFirstThread -cp jwm-0.3.1.jar:types-0.1.1.jar GettingStarted.java
 ```
 
 `types-0.1.1.jar` here are from https://github.com/HumbleUI/Types. They will be included as a transitive dependency if you are using Maven or Gradle.

--- a/docs/GettingStarted.java
+++ b/docs/GettingStarted.java
@@ -3,11 +3,11 @@ import io.github.humbleui.jwm.*;
 
 public class GettingStarted {
     public static void main(String[] args) {
-        App.init();
-        Window window = App.makeWindow();
-        window.setEventListener(new EventHandler(window));
-        window.setVisible(true);
-        App.start();
+        App.init(() -> {
+            Window window = App.makeWindow();
+            window.setEventListener(new EventHandler(window));
+            window.setVisible(true);
+        });
     }
 }
 

--- a/examples/dashboard/java/Example.java
+++ b/examples/dashboard/java/Example.java
@@ -218,8 +218,8 @@ public class Example implements Consumer<Event> {
     }
 
     public static void main(String[] args) {
-        App.init();
-        new Example();
-        App.start();
+        App.init(() -> {
+            new Example();
+        });
     }
 }

--- a/linux/cc/AppX11.cc
+++ b/linux/cc/AppX11.cc
@@ -89,11 +89,12 @@ const std::vector<jwm::ScreenInfo>& jwm::AppX11::getScreens() {
 
 // JNI
 
-extern "C" JNIEXPORT void JNICALL Java_io_github_humbleui_jwm_App__1nInit(JNIEnv* env, jclass jclass) {
+extern "C" JNIEXPORT void JNICALL Java_io_github_humbleui_jwm_App__1nInit(JNIEnv* env, jclass jclass, jobject launcher) {
     jwm::app.init(env);
-}
 
-extern "C" JNIEXPORT void JNICALL Java_io_github_humbleui_jwm_App__1nStart(JNIEnv* env, jclass jclass) {
+    // Call user start function
+    jwm::classes::Runnable::run(env, launcher);
+
     jwm::app.start();
 }
 

--- a/macos/cc/ApplicationDelegate.hh
+++ b/macos/cc/ApplicationDelegate.hh
@@ -1,7 +1,32 @@
 #pragma once
-#import <Cocoa/Cocoa.h>
 
-@interface ApplicationDelegate : NSObject<NSApplicationDelegate>
+#import <Cocoa/Cocoa.h>
+#include <jni.h>
+#import <jni.h>
+
+
+// http://trac.wxwidgets.org/ticket/13557
+// here we subclass NSApplication, for the purpose of being able to override sendEvent
+@interface JWMNSApplication: NSApplication {
+}
+
+- (id)init;
+
+- (void)sendEvent:(NSEvent *)anEvent;
+
+@end
+
+
+
+@interface ApplicationDelegate : NSObject<NSApplicationDelegate> {
+    JavaVM *jvm;
+    jobject launcher;
+}
+
+- (id)initWithJVM:(JavaVM *)vm andLauncherGlobalRef:(jobject)launcher;
+
+// Start the application, blocking until termination.
+- (void) runLoop;
 
 - (void)applicationDidFinishLaunching:(NSNotification *)notification;
 

--- a/macos/cc/ApplicationDelegate.mm
+++ b/macos/cc/ApplicationDelegate.mm
@@ -1,7 +1,62 @@
 #include "ApplicationDelegate.hh"
 
+#include "MainView.hh"
+
+@implementation JWMNSApplication
+
+- (id)init {
+    self = [super init];
+    return self;
+}
+
+// This is needed because otherwise we don't receive any key-up events for command-key combinations (an AppKit bug, apparently)
+- (void)sendEvent:(NSEvent *)anEvent {
+    if ([anEvent type] == NSEventTypeKeyUp && ([anEvent modifierFlags] & NSEventModifierFlagCommand))
+        [[self keyWindow] sendEvent:anEvent];
+    else
+        [super sendEvent:anEvent];
+}
+
+@end
+
+
+
 @implementation ApplicationDelegate {
 
+}
+
+- (id)initWithJVM: (JavaVM *)vm andLauncherGlobalRef: (jobject)launcherRef {
+    self = [super init];
+    self->jvm = vm;
+    self->launcher = launcherRef;
+    return self;
+}
+
+- (void) runLoop {
+
+    // Setup NSApplication
+    [JWMNSApplication sharedApplication];
+
+    [NSApp setDelegate:self];
+
+    jwm::initKeyTable();
+    jwm::initCursorCache();
+
+    // Call user launch runnable
+    JNIEnv *env; // get vm in current thread
+    JavaVMAttachArgs vmAttachArgs = {JNI_VERSION_1_8, 0, 0};
+    if (self->jvm->AttachCurrentThread((void**) &env, &vmAttachArgs) == JNI_OK) {
+        jwm::classes::Runnable::run(env, self->launcher);
+        env->DeleteGlobalRef(self->launcher);
+        self->launcher = nullptr;
+    }
+
+    // Run app
+    [NSApp run];
+}
+
+- (id)initWithJVM:(JavaVM *)pVm andLauncher:(jobject)launcher {
+    return nil;
 }
 
 - (void)applicationDidFinishLaunching:(NSNotification *)notification {

--- a/script/run.py
+++ b/script/run.py
@@ -49,7 +49,6 @@ def main():
   subprocess.check_call([
     'java',
     '--class-path', build_utils.classpath_join(classpath + ['examples/dashboard/target/classes']),
-    *(['-XstartOnFirstThread'] if 'macos' == build_utils.system else []),
     '-Djava.awt.headless=true',
     '-enableassertions',
     '-enablesystemassertions',

--- a/shared/java/App.java
+++ b/shared/java/App.java
@@ -35,7 +35,7 @@ public class App {
 
     /**
      * <p>Make new native platform-specific window.</p>
-     * <p>Note: must be called only after {@link #init()} successful method call.</p>
+     * <p>Note: must be called only after {@link #init(Runnable)} successful method call.</p>
      *
      * @return          new window instance
      */
@@ -57,8 +57,7 @@ public class App {
 
     /**
      * <p>Request application terminate.</p>
-     * <p>This request causes application terminate and causes control return from {@link #start()} method.</p>
-     * <p>Note: must be called only after {@link #init()} successful method call.</p>
+     * <p>Note: must be called only after {@link #init(Runnable)} successful method call.</p>
      */
     public static void terminate() {
         assert _onUIThread();
@@ -78,7 +77,7 @@ public class App {
 
     /**
      * <p>Get desktop environment screens configurations.</p>
-     * <p>Note: must be called only after {@link #init()} successful method call.</p>
+     * <p>Note: must be called only after {@link #init(Runnable)} successful method call.</p>
      *
      * @return          list of desktop screens
      */
@@ -89,7 +88,7 @@ public class App {
 
     /**
      * <p>Get desktop environment primary screen info.</p>
-     * <p>Note: must be called only after {@link #init()} successful method call.</p>
+     * <p>Note: must be called only after {@link #init(Runnable)} successful method call.</p>
      *
      * @return          primary desktop screen
      */

--- a/windows/cc/AppWin32.cc
+++ b/windows/cc/AppWin32.cc
@@ -66,13 +66,13 @@ LRESULT jwm::AppWin32::processEvent(UINT uMsg, WPARAM wParam, LPARAM lParam) {
 // JNI
 
 extern "C" JNIEXPORT void JNICALL Java_io_github_humbleui_jwm_App__1nInit
-        (JNIEnv* env, jclass jclass) {
+        (JNIEnv* env, jclass jclass, jobject launcher) {
     jwm::AppWin32::getInstance().init(env);
-}
 
-extern "C" JNIEXPORT jint JNICALL Java_io_github_humbleui_jwm_App__1nStart
-        (JNIEnv* env, jclass jclass) {
-    return jwm::AppWin32::getInstance().start();
+    // Call user start function
+    jwm::classes::Runnable::run(env, launcher);
+
+    jwm::AppWin32::getInstance().start();
 }
 
 extern "C" JNIEXPORT void JNICALL Java_io_github_humbleui_jwm_App__1nTerminate


### PR DESCRIPTION
The following does not require the start parameter to be set, and will move to the main thread for init when not already on it. The caveat being that all user init must be done in the callback added to `App#init`. 

!! I was _not_ able to test the changes on the linux/windows side. 

As always comments are very welcome, I have not worked with JNI much so it's very possible I made mistakes.

Also, `init` does not seem like a particularly descriptive name for `App#init` anymore.

Closes #210 