### PR TITLE
X11: clear modifiers on window unfocusing

### DIFF
--- a/linux/cc/KeyX11.cc
+++ b/linux/cc/KeyX11.cc
@@ -16,6 +16,10 @@ void jwm::KeyX11::setKeyState(jwm::Key key, bool isDown) {
     gKeyStates[(size_t) key] = isDown;
 }
 
+void jwm::KeyX11::resetKeyState() {
+    for (size_t i = 0; i < (size_t)jwm::Key::_KEY_COUNT; i++) gKeyStates[i] = 0;
+}
+
 int jwm::KeyX11::getModifiers() {
     int m = 0;
 

--- a/linux/cc/KeyX11.hh
+++ b/linux/cc/KeyX11.hh
@@ -8,6 +8,7 @@ namespace jwm {
         jwm::Key fromNative(uint32_t v);
         bool getKeyState(jwm::Key key);
         void setKeyState(jwm::Key key, bool isDown);
+        void resetKeyState();
         int getModifiers();
     }
 }

--- a/linux/cc/WindowManagerX11.cc
+++ b/linux/cc/WindowManagerX11.cc
@@ -536,6 +536,7 @@ void WindowManagerX11::_processXEvent(XEvent& ev) {
         }
 
         case FocusOut: { // unfocused
+            KeyX11::resetKeyState();
             myWindow->dispatch(EventWindowFocusOut::kInstance);
             break;
         }


### PR DESCRIPTION
A temporary-ish fix for #186; still leaves a dangling `KeyPressed` without a corresponding `KeyReleased` if you press a key, tab out, release key, tab back in. Fixing that would take some other much more complicated way.