### PR TITLE
X11: fix notifyLoop being called in parallel to main loop end

### DIFF
--- a/linux/cc/WindowManagerX11.cc
+++ b/linux/cc/WindowManagerX11.cc
@@ -242,11 +242,13 @@ void WindowManagerX11::runLoop() {
             break;
         }
 
-        // clear our pipe; ordering doesn't matter as any new events during clearing will be immediately processed
-        notifyBool.store(false);
+        // clear pipe
         if (ps[1].revents & POLLIN) {
             while (read(pipes[0], buf, sizeof(buf)) == sizeof(buf)) { }
         }
+        // clear fast path boolean; done after clearing the pipe so that, during event execution, new notifyLoop calls can still function
+        notifyBool.store(false);
+        // The events causing a notifyLoop anywhere between poll() end and here will be processed in all cases, as that's the next thing that happens
     }
     
     notifyFD = -1;


### PR DESCRIPTION
Currently, the following can happen:

1. Main thread: runs `notifyBool.store(false);`
2. Auxiliary thread: runs `notifyLoop`, `notifyBool.exchange(true)` returns false; writes character to pipe & sets `notifyBool` to true
3. Main thread: clears pipe

Now the pipe is clear, but `notifyBool` is true, meaning no `notifyLoop` call will do anything, and `poll()` will never respond.

[My comment](https://github.com/HumbleUI/JWM/blob/906ec6ed4f1d96408b6e7023b8ed857a5f6016d8/linux/cc/WindowManagerX11.cc#L245) was technically correct as the events corresponding to `notifyLoop` calls between the poll & notifyBool clears will be processed, but I failed to consider what happens after that :/