### PR TITLE
Resizing mouse cursors

### DIFF
--- a/linux/cc/WindowManagerX11.cc
+++ b/linux/cc/WindowManagerX11.cc
@@ -165,13 +165,25 @@ WindowManagerX11::WindowManagerX11():
             return XCreateFontCursor(display, alternativeId);
         };
         
-        _cursors[static_cast<int>(jwm::MouseCursor::ARROW         )] = loadCursor("default"     , XC_left_ptr );
-        _cursors[static_cast<int>(jwm::MouseCursor::CROSSHAIR     )] = loadCursor("crosshair"   , XC_left_ptr );
-        _cursors[static_cast<int>(jwm::MouseCursor::HELP          )] = loadCursor("help"        , XC_left_ptr );
-        _cursors[static_cast<int>(jwm::MouseCursor::POINTING_HAND )] = loadCursor("pointer"     , XC_hand2    );
-        _cursors[static_cast<int>(jwm::MouseCursor::IBEAM         )] = loadCursor("text"        , XC_xterm    );
-        _cursors[static_cast<int>(jwm::MouseCursor::NOT_ALLOWED   )] = loadCursor("not-allowed" , XC_left_ptr );
-        _cursors[static_cast<int>(jwm::MouseCursor::WAIT          )] = loadCursor("watch"       , XC_left_ptr );
+        _cursors[static_cast<int>(jwm::MouseCursor::ARROW         )] = loadCursor("default"     , XC_left_ptr           );
+        _cursors[static_cast<int>(jwm::MouseCursor::CROSSHAIR     )] = loadCursor("crosshair"   , XC_crosshair          );
+        _cursors[static_cast<int>(jwm::MouseCursor::HELP          )] = loadCursor("help"        , XC_question_arrow     );
+        _cursors[static_cast<int>(jwm::MouseCursor::POINTING_HAND )] = loadCursor("pointer"     , XC_hand2              );
+        _cursors[static_cast<int>(jwm::MouseCursor::IBEAM         )] = loadCursor("text"        , XC_xterm              );
+        _cursors[static_cast<int>(jwm::MouseCursor::NOT_ALLOWED   )] = loadCursor("not-allowed" , XC_pirate             );
+        _cursors[static_cast<int>(jwm::MouseCursor::WAIT          )] = loadCursor("watch"       , XC_watch              );
+        _cursors[static_cast<int>(jwm::MouseCursor::N_RESIZE      )] = loadCursor("n-resize"    , XC_top_side           );
+        _cursors[static_cast<int>(jwm::MouseCursor::E_RESIZE      )] = loadCursor("e-resize"    , XC_right_side         );
+        _cursors[static_cast<int>(jwm::MouseCursor::S_RESIZE      )] = loadCursor("s-resize"    , XC_bottom_side        );
+        _cursors[static_cast<int>(jwm::MouseCursor::W_RESIZE      )] = loadCursor("w-resize"    , XC_left_side          );
+        _cursors[static_cast<int>(jwm::MouseCursor::NE_RESIZE     )] = loadCursor("ne-resize"   , XC_top_right_corner   );
+        _cursors[static_cast<int>(jwm::MouseCursor::NW_RESIZE     )] = loadCursor("nw-resize"   , XC_top_left_corner    );
+        _cursors[static_cast<int>(jwm::MouseCursor::SE_RESIZE     )] = loadCursor("se-resize"   , XC_bottom_right_corner);
+        _cursors[static_cast<int>(jwm::MouseCursor::SW_RESIZE     )] = loadCursor("sw-resize"   , XC_bottom_left_corner );
+        _cursors[static_cast<int>(jwm::MouseCursor::EW_RESIZE     )] = loadCursor("ew-resize"   , XC_sb_h_double_arrow  );
+        _cursors[static_cast<int>(jwm::MouseCursor::NS_RESIZE     )] = loadCursor("ns-resize"   , XC_sb_v_double_arrow  );
+        _cursors[static_cast<int>(jwm::MouseCursor::NWSE_RESIZE   )] = loadCursor("nwse-resize" , XC_hand2              );
+        _cursors[static_cast<int>(jwm::MouseCursor::NESW_RESIZE   )] = loadCursor("nesw-resize" , XC_hand2              );
     }
 }
 

--- a/macos/cc/WindowMac.mm
+++ b/macos/cc/WindowMac.mm
@@ -42,6 +42,18 @@ void initCursorCache() {
                     cursorFromFile(@"notallowed"), /* NOT_ALLOWED */
                     [NSCursor arrowCursor],        /* WAIT */
                     [NSCursor arrowCursor],        /* WIN_UPARROW */
+                    [NSCursor resizeDown],         /* N_RESIZE */
+                    [NSCursor resizeLeft],         /* E_RESIZE */
+                    [NSCursor resizeUp],           /* S_RESIZE */
+                    [NSCursor resizeRight],        /* W_RESIZE */
+                    [NSCursor pointingHandCursor], /* NE_RESIZE */
+                    [NSCursor pointingHandCursor], /* NW_RESIZE */
+                    [NSCursor pointingHandCursor], /* SE_RESIZE */
+                    [NSCursor pointingHandCursor], /* SW_RESIZE */
+                    [NSCursor resizeLeftRight],    /* EW_RESIZE */
+                    [NSCursor resizeUpDown],       /* NS_RESIZE */
+                    [NSCursor pointingHandCursor], /* NESW_RESIZE */
+                    [NSCursor pointingHandCursor], /* NWSE_RESIZE */
                     nil];
     [kCursorCache retain];
 }

--- a/shared/cc/MouseCursor.hh
+++ b/shared/cc/MouseCursor.hh
@@ -2,7 +2,7 @@
 
 namespace jwm {
 
-    // Keep sync with MouseCursor.java
+    // Keep sync with MouseCursor.java and WindowMac.mm
     enum class MouseCursor {
         ARROW         = 0,
         CROSSHAIR     = 1,
@@ -12,7 +12,18 @@ namespace jwm {
         NOT_ALLOWED   = 5,
         WAIT          = 6,
         WIN_UPARROW   = 7,
-
+        N_RESIZE      = 8,
+        E_RESIZE      = 9,
+        S_RESIZE      = 10,
+        W_RESIZE      = 11,
+        NE_RESIZE     = 12,
+        NW_RESIZE     = 13,
+        SE_RESIZE     = 14,
+        SW_RESIZE     = 15,
+        EW_RESIZE     = 16,
+        NS_RESIZE     = 17,
+        NESW_RESIZE   = 18,
+        NWSE_RESIZE   = 19,
         // total enum count; keep this at the end
         COUNT,
     };
@@ -35,6 +46,30 @@ namespace jwm {
                 return "Wait";
             case MouseCursor::WIN_UPARROW:
                 return "UpArrow";
+            case MouseCursor::N_RESIZE:
+                return "N-resize";
+            case MouseCursor::E_RESIZE:
+                return "E-resize";
+            case MouseCursor::S_RESIZE:
+                return "S-resize";
+            case MouseCursor::W_RESIZE:
+                return "W-resize";
+            case MouseCursor::NE_RESIZE:
+                return "NE-resize";
+            case MouseCursor::NW_RESIZE:
+                return "NW-resize";
+            case MouseCursor::SE_RESIZE:
+                return "SE-resize";
+            case MouseCursor::SW_RESIZE:
+                return "SW-resize";
+            case MouseCursor::EW_RESIZE:
+                return "EW-resize";
+            case MouseCursor::NS_RESIZE:
+                return "NS-resize";
+            case MouseCursor::NESW_RESIZE:
+                return "NESW-resize";
+            case MouseCursor::NWSE_RESIZE:
+                return "NWSE-resize";
             default:
                 return "Unknown";
         }

--- a/shared/java/MouseCursor.java
+++ b/shared/java/MouseCursor.java
@@ -10,7 +10,19 @@ public enum MouseCursor {
     IBEAM,
     NOT_ALLOWED,
     WAIT,
-    WIN_UPARROW;
+    WIN_UPARROW,
+    N_RESIZE,
+    E_RESIZE,
+    S_RESIZE,
+    W_RESIZE,
+    NE_RESIZE,
+    NW_RESIZE,
+    SE_RESIZE,
+    SW_RESIZE,
+    EW_RESIZE,
+    NS_RESIZE,
+    NESW_RESIZE,
+    NWSE_RESIZE;
 
     @ApiStatus.Internal public static final MouseCursor[] _values = values();
 

--- a/windows/cc/WindowWin32.cc
+++ b/windows/cc/WindowWin32.cc
@@ -139,6 +139,31 @@ void jwm::WindowWin32::setMouseCursor(MouseCursor cursor) {
         case MouseCursor::WIN_UPARROW:
             cursorName = IDC_UPARROW;
             break;
+        
+        case MouseCursor::E_RESIZE:
+        case MouseCursor::W_RESIZE:
+        case MouseCursor::EW_RESIZE:
+            cursorName = IDC_SIZEWE;
+            break;
+        
+        case MouseCursor::N_RESIZE:
+        case MouseCursor::S_RESIZE:
+        case MouseCursor::NS_RESIZE:
+            cursorName = IDC_SIZENS;
+            break;
+        
+        case MouseCursor::NE_RESIZE:
+        case MouseCursor::SW_RESIZE:
+        case MouseCursor::NESW_RESIZE:
+            cursorName = IDC_SIZENESW;
+            break;
+        
+        case MouseCursor::NW_RESIZE:
+        case MouseCursor::SE_RESIZE:
+        case MouseCursor::NWSE_RESIZE:
+            cursorName = IDC_SIZENWSE;
+            break;
+        
         default:
             break;
     }


### PR DESCRIPTION
warning: completely untested on macOS or windows as I don't have access to those, but I tried to find some names for the icons for those OSes anyway.

Adds resizing cursors (plus more X11 definitions for the existing ones). Names taken from [CSS](https://developer.mozilla.org/en-US/docs/Web/CSS/cursor).