### PR TITLE
macOS: Implement window focus events

### DIFF
--- a/README.md
+++ b/README.md
@@ -152,8 +152,8 @@ Alpha. Expect API breakages.
 | EventWindowRestore      | ✅   | ✅   | [#96](https://github.com/HumbleUI/JWM/issues/96)   |
 | EventWindowVisible      | [#140](https://github.com/HumbleUI/JWM/issues/140) | [#140](https://github.com/HumbleUI/JWM/issues/140)   | [#140](https://github.com/HumbleUI/JWM/issues/140)   |
 | EventWindowScreenChange | [#117](https://github.com/HumbleUI/JWM/issues/117) | [#117](https://github.com/HumbleUI/JWM/issues/117) | [#117](https://github.com/HumbleUI/JWM/issues/117) |
-| EventWindowFocusIn      | ✅   | ❌   | ✅   |
-| EventWindowFocusOut     | ✅   | ❌   | ✅   |
+| EventWindowFocusIn      | ✅   | ✅   | ✅   |
+| EventWindowFocusOut     | ✅   | ✅   | ✅   |
 | Drag & Drop             | ❌   | ❌   | ❌   |
 | Touch events            | ❌   | ❌   | ❌   |
 | Theme Changed           | ❌   | ❌   | ❌   |

--- a/macos/cc/JWMWindowDelegate.mm
+++ b/macos/cc/JWMWindowDelegate.mm
@@ -52,6 +52,14 @@
     fWindow->dispatch(jwm::classes::EventWindowScreenChange::kInstance);
 }
 
+- (void)windowDidBecomeKey:(NSNotification *)notification {
+    fWindow->dispatch(jwm::classes::EventWindowFocusIn::kInstance);
+}
+
+- (void)windowDidResignKey:(NSNotification *)notification {
+    fWindow->dispatch(jwm::classes::EventWindowFocusOut::kInstance);
+}
+
 - (BOOL)windowShouldClose:(NSWindow*)sender {
     fWindow->dispatch(jwm::classes::EventWindowCloseRequest::kInstance);
     return FALSE;


### PR DESCRIPTION
Implements the EventWindowFocusIn and EventWindowFocusOut events on macOS. 

It is worth noting that macOS has different types of focus: whether the application is active, whether a window accepts input (key window) and whether a window is the main window (has the active appearance). This implementation listens to 'key window' events, because this gives expectations consistent with the X11 and Windows implementations.