### PR TITLE
macOS: Fix cursor resetting to arrow

### DIFF
--- a/examples/dashboard/java/PanelMouseCursors.java
+++ b/examples/dashboard/java/PanelMouseCursors.java
@@ -12,6 +12,7 @@ public class PanelMouseCursors extends Panel {
     public EventMouseMove lastMove = new EventMouseMove(0, 0, 0, 0);
     public Map<IRect, MouseCursor> rects = new HashMap<>();
     public boolean lastInside = false;
+    public boolean keepCursor = false;
 
     public PanelMouseCursors(Window window) {
         super(window);
@@ -23,7 +24,6 @@ public class PanelMouseCursors extends Panel {
             lastMove = ee;
             var inside = contains(ee.getX(), ee.getY());
             if (inside || lastInside) {
-                lastInside = inside;
                 var relX = lastMove.getX() - lastX;
                 var relY = lastMove.getY() - lastY;
 
@@ -36,10 +36,17 @@ public class PanelMouseCursors extends Panel {
                         return;
                     }
                 }
-                if (window._lastCursor != MouseCursor.ARROW)
-                    window.requestFrame();
-                window.setMouseCursor(MouseCursor.ARROW);
+                if (!inside && lastInside) {
+                    keepCursor = false;
+                } else if (!keepCursor) {
+                    if (window._lastCursor != MouseCursor.ARROW)
+                        window.requestFrame();
+                    window.setMouseCursor(MouseCursor.ARROW);
+                }
+                lastInside = inside;
             }
+        } else if (e instanceof EventMouseButton ee && ee.isPressed() && lastInside) {
+            keepCursor = true;
         }
     }
 

--- a/macos/cc/JWMMainView.mm
+++ b/macos/cc/JWMMainView.mm
@@ -342,6 +342,10 @@ static const NSRange kEmptyRange = { NSNotFound, 0 };
     onMouseButton(fWindow, event, &fLastPressedButtons);
 }
 
+- (void)cursorUpdate:(NSEvent *)event {
+    [fWindow->fCursor set];
+}
+
 - (void)scrollWheel:(NSEvent *)event {
     jint modifierMask = jwm::modifierMask([event modifierFlags]);
     CGFloat deltaX;

--- a/macos/cc/WindowMac.hh
+++ b/macos/cc/WindowMac.hh
@@ -25,6 +25,7 @@ namespace jwm {
         NSWindow* fNSWindow = nullptr;
         NSPoint fLastPosition = {0, 0};
         NSRect fRestoreFrame = NSZeroRect;
+        NSCursor* fCursor = nullptr;
         CVDisplayLinkRef fDisplayLink = 0;
         std::atomic_bool fVisible {false};
         std::atomic_bool fFrameRequested {false};

--- a/macos/cc/WindowMac.mm
+++ b/macos/cc/WindowMac.mm
@@ -97,6 +97,8 @@ bool jwm::WindowMac::init() {
         return false;
     }
 
+    fCursor = [kCursorCache objectAtIndex:0];
+
     // create view
     JWMMainView* view = [[JWMMainView alloc] initWithWindow:this];
     if (nil == view) {
@@ -432,6 +434,7 @@ extern "C" JNIEXPORT void JNICALL Java_io_github_humbleui_jwm_WindowMac__1nSetMo
   (JNIEnv* env, jobject obj, jint cursorIdx) {
     jwm::WindowMac* instance = reinterpret_cast<jwm::WindowMac*>(jwm::classes::Native::fromJava(env, obj));
     NSCursor* cursor = [jwm::kCursorCache objectAtIndex:cursorIdx];
+    instance->fCursor = cursor;
     [cursor set];
 }
 


### PR DESCRIPTION
After using `setMouseCursor`, I noticed that when the cursor leaves the window and re-enters, it returns to the default arrow cursor.

The solutions to this are to use either `addCursorRect:cursor:` or `NSTrackingArea` to ensure the cursor is set back to the preferred image. This implementation builds on the existing tracking area, which I think is better than [an implementation using cursor rects](https://github.com/HumbleUI/JWM/compare/0.4.4...LuisThiamNye:JWM:luistn/cursors?expand=1).

Also, this patch includes a small modification to the dashboard example which allows you to click to the mouse cursor panel to keep the current cursor set until another element sets it back. As a result, the effect of this patch can be clearly seen.

