### PR TITLE
linux: avoid crash on empty X11 resources

### DIFF
--- a/linux/cc/AppX11.cc
+++ b/linux/cc/AppX11.cc
@@ -22,9 +22,8 @@ float jwm::AppX11::getScale() {
         }
     } once;
 
-    db = XrmGetStringDatabase(resourceString);
-
     if (resourceString) {
+        db = XrmGetStringDatabase(resourceString);
         if (XrmGetResource(db, "Xft.dpi", "String", &type, &value)) {
             if (value.addr) {
                 return atof(value.addr) / 96.f;


### PR DESCRIPTION
Running under XWayland, or just under my setup, XResourceManagerString returns null. This avoids the XrmGetStringDatabase crash.