### PR TITLE
X11: Clear all scroll valuators on XI_Enter

### DIFF
--- a/linux/cc/WindowManagerX11.cc
+++ b/linux/cc/WindowManagerX11.cc
@@ -331,15 +331,10 @@ void WindowManagerX11::_processXEvent(XEvent& ev) {
                             break;
                         }
 
-                        auto itMyDevice = _xi2->deviceById.find(deviceEvent->sourceid);
-                        if (itMyDevice == _xi2->deviceById.end()) {
-                            break;
-                        }
-
-                        XInput2::Device& myDevice = itMyDevice->second;
-
-                        for (auto& valuator : myDevice.scroll) {
-                            valuator.previousValue = 0;
+                        for (auto& device : _xi2->deviceById) {
+                            for (auto& valuator : device.second.scroll) {
+                                valuator.previousValue = 0;
+                            }
                         }
                         break;
                     }


### PR DESCRIPTION
My previous X11 PR (#244) introduced an issue where tabbing out & back into a window didn't clear the scroll valuator (just moving mouse out & in did work, which is what I had tested). I don't see a way to clear them precisely here, as neither the sourceid nor deviceid is the ID that stores the valuator, without introducing a map from device to source IDs, so this patch just clears all unconditionally.

Given that the IDs are the same between multiple JWM windows (at least on my Linux Mint 21 system), I don't think this should affect anything either.