### PR TITLE
macOS: add EventTouchFrame

### DIFF
--- a/examples/dashboard/java/PanelTouch.java
+++ b/examples/dashboard/java/PanelTouch.java
@@ -25,15 +25,13 @@ public class PanelTouch extends Panel {
             touchDevices.put(ee.getDeviceId(), ee.getId());
             devices.put(ee.getDeviceId(), new Point(ee.getDeviceWidth(), ee.getDeviceHeight()));
             touches.put(ee.getId(), new Point(ee.getFracX(), ee.getFracY()));
-            window.requestFrame();
         } else if (e instanceof EventTouchMove ee) {
             touches.put(ee.getId(), new Point(ee.getFracX(), ee.getFracY()));
-            window.requestFrame();
         } else if (e instanceof EventTouchCancel ee) {
             touches.remove(ee.getId());
-            window.requestFrame();
         } else if (e instanceof EventTouchEnd ee) {
             touches.remove(ee.getId());
+        } else if (e instanceof EventTouchFrame ee) {
             window.requestFrame();
         }
     }

--- a/macos/cc/JWMMainView.mm
+++ b/macos/cc/JWMMainView.mm
@@ -326,6 +326,9 @@ void onTouch(jwm::WindowMac* window, NSEvent* event, NSTouchPhase phase, NSMutab
             removeTouch(window, phase, touch.identity, touchId, touchIds, touchCount);
         }
     }
+    // signal end of batched touch frame
+    jwm::JNILocal<jobject> eventObj(window->fEnv, jwm::classes::EventTouchFrame::make(window->fEnv));
+    window->dispatch(eventObj.get());
 }
 
 } // namespace jwm

--- a/shared/cc/impl/Library.cc
+++ b/shared/cc/impl/Library.cc
@@ -369,6 +369,24 @@ namespace jwm {
             }
         }
 
+        namespace EventTouchFrame {
+            jclass kCls;
+            jmethodID kCtor;
+
+            void onLoad(JNIEnv* env) {
+                JNILocal<jclass> cls(env, env->FindClass("io/github/humbleui/jwm/EventTouchFrame"));
+                Throwable::exceptionThrown(env);
+                kCls = static_cast<jclass>(env->NewGlobalRef(cls.get()));
+                kCtor = env->GetMethodID(kCls, "<init>", "()V");
+                Throwable::exceptionThrown(env);
+            }
+
+            jobject make(JNIEnv* env) {
+                jobject res = env->NewObject(kCls, kCtor);
+                return Throwable::exceptionThrown(env) ? nullptr : res;
+            }
+        }
+
         namespace EventTextInput {
             jclass kCls;
             jmethodID kCtor;
@@ -665,6 +683,7 @@ extern "C" JNIEXPORT void JNICALL Java_io_github_humbleui_jwm_impl_Library__1nAf
     jwm::classes::EventTouchMove::onLoad(env);
     jwm::classes::EventTouchCancel::onLoad(env);
     jwm::classes::EventTouchEnd::onLoad(env);
+    jwm::classes::EventTouchFrame::onLoad(env);
     jwm::classes::EventTextInput::onLoad(env);
     jwm::classes::EventTextInputMarked::onLoad(env);
     jwm::classes::EventWindowCloseRequest::onLoad(env);

--- a/shared/cc/impl/Library.hh
+++ b/shared/cc/impl/Library.hh
@@ -132,6 +132,12 @@ namespace jwm {
             jobject make(JNIEnv* env, jint id);
         }
 
+        namespace EventTouchFrame {
+            extern jclass kCls;
+            extern jmethodID kCtor;
+            jobject make(JNIEnv* env);
+        }
+
         namespace EventTextInput {
             extern jclass kCls;
             extern jmethodID kCtor;

--- a/shared/java/EventTouchFrame.java
+++ b/shared/java/EventTouchFrame.java
@@ -1,0 +1,8 @@
+package io.github.humbleui.jwm;
+
+import lombok.*;
+import org.jetbrains.annotations.*;
+
+@Data
+public class EventTouchFrame implements Event {
+}


### PR DESCRIPTION
Hopefully last thing for #249.

This event allows us to do something at the end of a touch frame.  e.g. PanelTouch now uses it to request a redraw after it receives all the touch events for that frame.

<img width="462" alt="CleanShot 2022-12-12 at 15 30 04@2x" src="https://user-images.githubusercontent.com/116838/207158672-d67f86d6-1bd4-4298-b054-1bd838be09dd.png">