### PR TITLE
Add javadoc -encoding UTF-8 to fix package.py unmappable char

### DIFF
--- a/docs/windows/build.md
+++ b/docs/windows/build.md
@@ -41,7 +41,7 @@ Then, run `C:\Program Files (x86)\Microsoft Visual Studio\Installer\setup.exe` a
 
 After reboot, open one of the command prompts for VS 2019 matching your arch.
 
-Usually, you can open command prompt for VS from `C:\path\to\Start Menu\Programs\Visual Studio 2019\Visual Studio Tools\VC`.
+For a standard 64-bit build, try the VS `x64` command prompt, usually located at `C:\path\to\Start Menu\Programs\Visual Studio 2019\Visual Studio Tools\VC`.
 
 ### Configure path and env (optional)
 
@@ -88,10 +88,8 @@ You will get something like this.
 
 ![example application](./example_app.jpg)
 
-## troubleshooting
+## Troubleshooting
 - disable other c++ compilers like minGW
 - try removing windows/build directory and re-run command
-- run `python ./script/crean.py`
+- run `python ./script/clean.py`
 - check environment variables and paths (`echo`, `where <cmd>` in power shell or `which <cmd>` in unix-like shell)
-
-

--- a/script/build_utils.py
+++ b/script/build_utils.py
@@ -145,6 +145,7 @@ def javadoc(dirs: List[str], target: str, classpath: List[str] = [], modulepath:
     subprocess.check_call(["javadoc",
       *(["--class-path", classpath_join(classpath)] if classpath else []),
       *(["--module-path", classpath_join(modulepath)] if modulepath else []),
+      "-encoding", "UTF-8",
       "-d", target,
       "-quiet",
       "-Xdoclint:all,-missing",


### PR DESCRIPTION
Fixes javadoc "unmappable character for encoding windows-1252", which was appearing during `python scripts/package.py` on my installation. Full error:

```
Generating JavaDoc target/delomboked to target/apidocs
target\delomboked\io\github\humbleui\jwm\EventMouseScroll.java:10: error: unmappable character (0x90) for encoding windows-1252
     * Direction Γå? + / ΓêÆ ΓåÆ
                   ^
target\delomboked\io\github\humbleui\jwm\EventMouseScroll.java:65: error: unmappable character (0x90) for encoding windows-1252
     * Direction Γå? + / ΓêÆ ΓåÆ
                   ^
target\delomboked\io\github\humbleui\jwm\ZOrder.java:9: error: unmappable character (0x9D) for encoding windows-1252
    /** Default ΓÇ£Always on topΓÇ? behavior */
                                  ^
3 errors
Traceback (most recent call last):
  File "C:\Users\Quest\repos\humbleui\JWM\script\package.py", line 38, in <module>
    main()
  File "C:\Users\Quest\repos\humbleui\JWM\script\package.py", line 32, in main
    build_utils.javadoc(["target/delomboked"], "target/apidocs", classpath=common.deps_compile())
  File "C:\Users\Quest\repos\humbleui\JWM\script\build_utils.py", line 145, in javadoc
    subprocess.check_call(["javadoc",
  File "C:\Python310\lib\subprocess.py", line 369, in check_call
    raise CalledProcessError(retcode, cmd)
subprocess.CalledProcessError: Command '['javadoc', '--class-path', 
```

Also tweaks windows/build.md to be slightly more specific. Should help guide unfamiliar users towards the correct way to compile under VS (#264)