### PR TITLE
Add Window bringToFront & isFront, Windows impl

### DIFF
--- a/linux/java/WindowX11.java
+++ b/linux/java/WindowX11.java
@@ -156,10 +156,17 @@ public class WindowX11 extends Window {
     }
 
     @Override
-    public Window stealFocus() {
+    public Window bringToFront() {
         assert _onUIThread();
         // TODO implement
         return this;
+    }
+
+    @Override
+    public boolean isFront() {
+        assert _onUIThread();
+        // TODO: impl me
+        return false;
     }
 
     @Override

--- a/linux/java/WindowX11.java
+++ b/linux/java/WindowX11.java
@@ -156,14 +156,7 @@ public class WindowX11 extends Window {
     }
 
     @Override
-    public Window setActiveWindow() {
-        assert _onUIThread();
-        // TODO implement
-        return this;
-    }
-
-    @Override
-    public Window setForegroundWindow() {
+    public Window stealFocus() {
         assert _onUIThread();
         // TODO implement
         return this;

--- a/linux/java/WindowX11.java
+++ b/linux/java/WindowX11.java
@@ -156,6 +156,20 @@ public class WindowX11 extends Window {
     }
 
     @Override
+    public Window setActiveWindow() {
+        assert _onUIThread();
+        // TODO implement
+        return this;
+    }
+
+    @Override
+    public Window setForegroundWindow() {
+        assert _onUIThread();
+        // TODO implement
+        return this;
+    }
+
+    @Override
     public ZOrder getZOrder() {
         assert _onUIThread();
         return ZOrder.NORMAL;

--- a/macos/java/WindowMac.java
+++ b/macos/java/WindowMac.java
@@ -249,14 +249,7 @@ public class WindowMac extends Window {
     }
 
     @Override
-    public Window setActiveWindow() {
-        assert _onUIThread();
-        // TODO: impl me
-        return this;
-    }
-
-    @Override
-    public Window setForegroundWindow() {
+    public Window stealFocus() {
         assert _onUIThread();
         // TODO: impl me
         return this;
@@ -322,8 +315,7 @@ public class WindowMac extends Window {
     @ApiStatus.Internal public native void _nSetFullScreen(boolean value);
     @ApiStatus.Internal public native boolean _nIsFullScreen();
     @ApiStatus.Internal public native void _nFocus();
-    @ApiStatus.Internal public native void _nSetActiveWindow();
-    @ApiStatus.Internal public native void _nSetForegroundWindow();
+    @ApiStatus.Internal public native void _nstealFocus();
     @ApiStatus.Internal public native int _nGetZOrder();
     @ApiStatus.Internal public native void _nSetZOrder(int zOrder);
     @ApiStatus.Internal public native void _nSetProgressBar(float value);

--- a/macos/java/WindowMac.java
+++ b/macos/java/WindowMac.java
@@ -249,10 +249,17 @@ public class WindowMac extends Window {
     }
 
     @Override
-    public Window stealFocus() {
+    public Window bringToFront() {
         assert _onUIThread();
         // TODO: impl me
         return this;
+    }
+
+    @Override
+    public boolean isFront() {
+        assert _onUIThread();
+        // TODO: impl me
+        return false;
     }
 
     @Override
@@ -315,7 +322,6 @@ public class WindowMac extends Window {
     @ApiStatus.Internal public native void _nSetFullScreen(boolean value);
     @ApiStatus.Internal public native boolean _nIsFullScreen();
     @ApiStatus.Internal public native void _nFocus();
-    @ApiStatus.Internal public native void _nstealFocus();
     @ApiStatus.Internal public native int _nGetZOrder();
     @ApiStatus.Internal public native void _nSetZOrder(int zOrder);
     @ApiStatus.Internal public native void _nSetProgressBar(float value);

--- a/macos/java/WindowMac.java
+++ b/macos/java/WindowMac.java
@@ -249,6 +249,20 @@ public class WindowMac extends Window {
     }
 
     @Override
+    public Window setActiveWindow() {
+        assert _onUIThread();
+        // TODO: impl me
+        return this;
+    }
+
+    @Override
+    public Window setForegroundWindow() {
+        assert _onUIThread();
+        // TODO: impl me
+        return this;
+    }
+
+    @Override
     public ZOrder getZOrder() {
         assert _onUIThread();
         return ZOrder._values[_nGetZOrder()];
@@ -308,6 +322,8 @@ public class WindowMac extends Window {
     @ApiStatus.Internal public native void _nSetFullScreen(boolean value);
     @ApiStatus.Internal public native boolean _nIsFullScreen();
     @ApiStatus.Internal public native void _nFocus();
+    @ApiStatus.Internal public native void _nSetActiveWindow();
+    @ApiStatus.Internal public native void _nSetForegroundWindow();
     @ApiStatus.Internal public native int _nGetZOrder();
     @ApiStatus.Internal public native void _nSetZOrder(int zOrder);
     @ApiStatus.Internal public native void _nSetProgressBar(float value);

--- a/shared/java/Window.java
+++ b/shared/java/Window.java
@@ -354,7 +354,9 @@ public abstract class Window extends RefCounted implements Consumer<Event> {
     public abstract Window focus();
 
     /**
-     * Try to steal operating-system level focus onto current window
+     * <p>Try to steal operating-system level focus onto current window.</p>
+     * <p>This can bring the window to the foreground in situations where</p>
+     * <p>plain focus() might be suppressed by the operating system.</p>
      *
      * @return  this
      */

--- a/shared/java/Window.java
+++ b/shared/java/Window.java
@@ -354,18 +354,11 @@ public abstract class Window extends RefCounted implements Consumer<Event> {
     public abstract Window focus();
 
     /**
-     * Set current window to active
+     * Try to steal operating-system level focus onto current window
      *
      * @return  this
      */
-    public abstract Window setActiveWindow();
-
-    /**
-     * Set current window to foreground
-     *
-     * @return  this
-     */
-    public abstract Window setForegroundWindow();
+    public abstract Window stealFocus();
 
     /**
      * @return  current Z order

--- a/shared/java/Window.java
+++ b/shared/java/Window.java
@@ -348,10 +348,24 @@ public abstract class Window extends RefCounted implements Consumer<Event> {
 
     /**
      * Focus current window
-     * 
+     *
      * @return  this
      */
     public abstract Window focus();
+
+    /**
+     * Set current window to active
+     *
+     * @return  this
+     */
+    public abstract Window setActiveWindow();
+
+    /**
+     * Set current window to foreground
+     *
+     * @return  this
+     */
+    public abstract Window setForegroundWindow();
 
     /**
      * @return  current Z order

--- a/shared/java/Window.java
+++ b/shared/java/Window.java
@@ -354,13 +354,19 @@ public abstract class Window extends RefCounted implements Consumer<Event> {
     public abstract Window focus();
 
     /**
-     * <p>Try to steal operating-system level focus onto current window.</p>
-     * <p>This can bring the window to the foreground in situations where</p>
-     * <p>plain focus() might be suppressed by the operating system.</p>
+     * <p>Bring window to front-most position in operating-system.</p>
+     * <p>This can bring the window out of the system's backgrounded apps.</p>
      *
      * @return  this
      */
-    public abstract Window stealFocus();
+    public abstract Window bringToFront();
+
+    /**
+     * Checks if window is currently the front-most one in the parent operating system.
+     *
+     * @return  boolean
+     */
+    public abstract boolean isFront();
 
     /**
      * @return  current Z order

--- a/windows/cc/WindowWin32.cc
+++ b/windows/cc/WindowWin32.cc
@@ -200,6 +200,14 @@ void jwm::WindowWin32::setForegroundWindow() {
     SetForegroundWindow(_hWnd);
 }
 
+void jwm::WindowWin32::stealFocus() {
+    JWM_VERBOSE("Set focus on window 0x" << this);
+    restore();
+    setForegroundWindow();
+    setActiveWindow();
+    focus();
+}
+
 void jwm::WindowWin32::requestSwap() {
     if (testFlag(Flag::HasAttachedLayer)) {
         setFlag(Flag::RequestSwap);
@@ -1076,6 +1084,12 @@ extern "C" JNIEXPORT void JNICALL Java_io_github_humbleui_jwm_WindowWin32__1nSet
         (JNIEnv* env, jobject obj) {
     jwm::WindowWin32* instance = reinterpret_cast<jwm::WindowWin32*>(jwm::classes::Native::fromJava(env, obj));
     instance->setForegroundWindow();
+}
+
+extern "C" JNIEXPORT void JNICALL Java_io_github_humbleui_jwm_WindowWin32__1nStealFocus
+        (JNIEnv* env, jobject obj) {
+    jwm::WindowWin32* instance = reinterpret_cast<jwm::WindowWin32*>(jwm::classes::Native::fromJava(env, obj));
+    instance->stealFocus();
 }
 
 extern "C" JNIEXPORT void JNICALL Java_io_github_humbleui_jwm_WindowWin32__1nClose

--- a/windows/cc/WindowWin32.cc
+++ b/windows/cc/WindowWin32.cc
@@ -190,6 +190,16 @@ void jwm::WindowWin32::focus() {
     SetFocus(_hWnd);
 }
 
+void jwm::WindowWin32::setActiveWindow() {
+    JWM_VERBOSE("Setting active on window 0x" << this);
+    SetActiveWindow(_hWnd);
+}
+
+void jwm::WindowWin32::setForegroundWindow() {
+    JWM_VERBOSE("Setting foreground on window 0x" << this);
+    SetForegroundWindow(_hWnd);
+}
+
 void jwm::WindowWin32::requestSwap() {
     if (testFlag(Flag::HasAttachedLayer)) {
         setFlag(Flag::RequestSwap);
@@ -1054,6 +1064,18 @@ extern "C" JNIEXPORT void JNICALL Java_io_github_humbleui_jwm_WindowWin32__1nFoc
         (JNIEnv* env, jobject obj) {
     jwm::WindowWin32* instance = reinterpret_cast<jwm::WindowWin32*>(jwm::classes::Native::fromJava(env, obj));
     instance->focus();
+}
+
+extern "C" JNIEXPORT void JNICALL Java_io_github_humbleui_jwm_WindowWin32__1nSetActiveWindow
+        (JNIEnv* env, jobject obj) {
+    jwm::WindowWin32* instance = reinterpret_cast<jwm::WindowWin32*>(jwm::classes::Native::fromJava(env, obj));
+    instance->setActiveWindow();
+}
+
+extern "C" JNIEXPORT void JNICALL Java_io_github_humbleui_jwm_WindowWin32__1nSetForegroundWindow
+        (JNIEnv* env, jobject obj) {
+    jwm::WindowWin32* instance = reinterpret_cast<jwm::WindowWin32*>(jwm::classes::Native::fromJava(env, obj));
+    instance->setForegroundWindow();
 }
 
 extern "C" JNIEXPORT void JNICALL Java_io_github_humbleui_jwm_WindowWin32__1nClose

--- a/windows/cc/WindowWin32.cc
+++ b/windows/cc/WindowWin32.cc
@@ -195,17 +195,43 @@ void jwm::WindowWin32::setActiveWindow() {
     SetActiveWindow(_hWnd);
 }
 
+HWND jwm::WindowWin32::getForegroundWindow() {
+    JWM_VERBOSE("Getting system foreground window");
+    return GetForegroundWindow();
+}
+
 void jwm::WindowWin32::setForegroundWindow() {
     JWM_VERBOSE("Setting foreground on window 0x" << this);
     SetForegroundWindow(_hWnd);
 }
 
+long jwm::WindowWin32::getCurrentThreadId() {
+    JWM_VERBOSE("Getting current thread ID of window 0x" << this);
+    return GetCurrentThreadId();
+}
+
+long jwm::WindowWin32::getWindowThreadProcessId(HWND hWnd) {
+    JWM_VERBOSE("Getting thread ID of window 0x" << hWnd);
+    return GetWindowThreadProcessId(hWnd, NULL);
+}
+
+void jwm::WindowWin32::attachThreadInput(long parentThreadId, long childThreadId, bool attachOrDetach) {
+    if (attachOrDetach) {
+        JWM_VERBOSE("Attaching thread input of thread " << childThreadId << " to " << parentThreadId);
+    } else {
+        JWM_VERBOSE("Detaching thread input of thread " << childThreadId << " from " << parentThreadId);
+    }
+    AttachThreadInput(parentThreadId, childThreadId, attachOrDetach);
+}
+
 void jwm::WindowWin32::stealFocus() {
-    JWM_VERBOSE("Set focus on window 0x" << this);
-    restore();
+    JWM_VERBOSE("Stealing system focus onto window 0x" << this);
+    HWND hCurrentWindow = getForegroundWindow();
+    long currentThreadId = getWindowThreadProcessId(hCurrentWindow);
+    long jwmThreadId = getCurrentThreadId();
+    attachThreadInput(currentThreadId, jwmThreadId, true);
     setForegroundWindow();
-    setActiveWindow();
-    focus();
+    attachThreadInput(currentThreadId, jwmThreadId, false);
 }
 
 void jwm::WindowWin32::requestSwap() {
@@ -1080,10 +1106,34 @@ extern "C" JNIEXPORT void JNICALL Java_io_github_humbleui_jwm_WindowWin32__1nSet
     instance->setActiveWindow();
 }
 
+extern "C" JNIEXPORT HWND JNICALL Java_io_github_humbleui_jwm_WindowWin32__1nGetForegroundWindow
+        (JNIEnv* env, jobject obj) {
+    jwm::WindowWin32* instance = reinterpret_cast<jwm::WindowWin32*>(jwm::classes::Native::fromJava(env, obj));
+    return instance->getForegroundWindow();
+}
+
 extern "C" JNIEXPORT void JNICALL Java_io_github_humbleui_jwm_WindowWin32__1nSetForegroundWindow
         (JNIEnv* env, jobject obj) {
     jwm::WindowWin32* instance = reinterpret_cast<jwm::WindowWin32*>(jwm::classes::Native::fromJava(env, obj));
     instance->setForegroundWindow();
+}
+
+extern "C" JNIEXPORT jlong JNICALL Java_io_github_humbleui_jwm_WindowWin32__1nGetCurrentThreadId
+        (JNIEnv* env, jobject obj) {
+    jwm::WindowWin32* instance = reinterpret_cast<jwm::WindowWin32*>(jwm::classes::Native::fromJava(env, obj));
+    return instance->getCurrentThreadId();
+}
+
+extern "C" JNIEXPORT jlong JNICALL Java_io_github_humbleui_jwm_WindowWin32__1nGetWindowThreadProcessId
+        (JNIEnv* env, jobject obj, HWND hwnd) {
+    jwm::WindowWin32* instance = reinterpret_cast<jwm::WindowWin32*>(jwm::classes::Native::fromJava(env, obj));
+    return instance->getWindowThreadProcessId(hwnd);
+}
+
+extern "C" JNIEXPORT void JNICALL Java_io_github_humbleui_jwm_WindowWin32__1nAttachThreadInput
+(JNIEnv* env, jobject obj, long parentThreadId, long childThreadId, bool attachOrDetach) {
+    jwm::WindowWin32* instance = reinterpret_cast<jwm::WindowWin32*>(jwm::classes::Native::fromJava(env, obj));
+    instance->attachThreadInput(parentThreadId, childThreadId, attachOrDetach);
 }
 
 extern "C" JNIEXPORT void JNICALL Java_io_github_humbleui_jwm_WindowWin32__1nStealFocus

--- a/windows/cc/WindowWin32.hh
+++ b/windows/cc/WindowWin32.hh
@@ -61,13 +61,8 @@ namespace jwm {
         void minimize();
         void restore();
         void focus();
-        void setActiveWindow();
-        HWND getForegroundWindow(); // Note asymmetry between get/setForegroundWindow
-        void setForegroundWindow();
-        long getCurrentThreadId();
-        long getWindowThreadProcessId(HWND hWnd);
-        void attachThreadInput(long parentThreadId, long childThreadId, bool attachOrDetach);
-        void stealFocus();
+        void bringToFront();
+        bool isFront();
         void requestSwap();
         void requestFrame();
         IRect getWindowRect() const;

--- a/windows/cc/WindowWin32.hh
+++ b/windows/cc/WindowWin32.hh
@@ -61,6 +61,8 @@ namespace jwm {
         void minimize();
         void restore();
         void focus();
+        void setActiveWindow();
+        void setForegroundWindow();
         void requestSwap();
         void requestFrame();
         IRect getWindowRect() const;

--- a/windows/cc/WindowWin32.hh
+++ b/windows/cc/WindowWin32.hh
@@ -62,7 +62,11 @@ namespace jwm {
         void restore();
         void focus();
         void setActiveWindow();
+        HWND getForegroundWindow(); // Note asymmetry between get/setForegroundWindow
         void setForegroundWindow();
+        long getCurrentThreadId();
+        long getWindowThreadProcessId(HWND hWnd);
+        void attachThreadInput(long parentThreadId, long childThreadId, bool attachOrDetach);
         void stealFocus();
         void requestSwap();
         void requestFrame();

--- a/windows/cc/WindowWin32.hh
+++ b/windows/cc/WindowWin32.hh
@@ -63,6 +63,7 @@ namespace jwm {
         void focus();
         void setActiveWindow();
         void setForegroundWindow();
+        void stealFocus();
         void requestSwap();
         void requestFrame();
         IRect getWindowRect() const;

--- a/windows/java/WindowWin32.java
+++ b/windows/java/WindowWin32.java
@@ -172,10 +172,30 @@ public class WindowWin32 extends Window {
         return this;
     }
 
+    public long getForegroundWindow() {
+        assert _onUIThread();
+        return _nGetForegroundWindow();
+    }
+
     public Window setForegroundWindow() {
         assert _onUIThread();
         _nSetForegroundWindow();
         return this;
+    }
+
+    public long getCurrentThreadId() {
+        assert _onUIThread();
+        return _nGetCurrentThreadId();
+    }
+
+    public long attachThreadInput(long parentThreadId, long childThreadId, boolean attachOrDetach) {
+        assert _onUIThread();
+        return _nAttachThreadInput(parentThreadId, childThreadId, attachOrDetach);
+    }
+
+    public long getWindowThreadProcessId(long hWnd) {
+        assert _onUIThread();
+        return _nGetWindowThreadProcessId(hWnd);
     }
 
     @Override
@@ -242,7 +262,11 @@ public class WindowWin32 extends Window {
     @ApiStatus.Internal public native void _nRestore();
     @ApiStatus.Internal public native void _nFocus();
     @ApiStatus.Internal public native void _nSetActiveWindow();
+    @ApiStatus.Internal public native long _nGetForegroundWindow();
     @ApiStatus.Internal public native void _nSetForegroundWindow();
+    @ApiStatus.Internal public native long _nGetCurrentThreadId();
+    @ApiStatus.Internal public native long _nGetWindowThreadProcessId(long hwnd);
+    @ApiStatus.Internal public native long _nAttachThreadInput(long parentThreadId, long childThreadId, boolean attachOrDetach);
     @ApiStatus.Internal public native void _nStealFocus();
     @ApiStatus.Internal public native void _nClose();
     @ApiStatus.Internal public native void _nWinSetParent(long hwnd);

--- a/windows/java/WindowWin32.java
+++ b/windows/java/WindowWin32.java
@@ -166,17 +166,22 @@ public class WindowWin32 extends Window {
         return this;
     }
 
-    @Override
     public Window setActiveWindow() {
         assert _onUIThread();
         _nSetForegroundWindow();
         return this;
     }
 
-    @Override
     public Window setForegroundWindow() {
         assert _onUIThread();
         _nSetForegroundWindow();
+        return this;
+    }
+
+    @Override
+    public Window stealFocus() {
+        assert _onUIThread();
+        _nStealFocus();
         return this;
     }
 
@@ -238,6 +243,7 @@ public class WindowWin32 extends Window {
     @ApiStatus.Internal public native void _nFocus();
     @ApiStatus.Internal public native void _nSetActiveWindow();
     @ApiStatus.Internal public native void _nSetForegroundWindow();
+    @ApiStatus.Internal public native void _nStealFocus();
     @ApiStatus.Internal public native void _nClose();
     @ApiStatus.Internal public native void _nWinSetParent(long hwnd);
 }

--- a/windows/java/WindowWin32.java
+++ b/windows/java/WindowWin32.java
@@ -167,6 +167,20 @@ public class WindowWin32 extends Window {
     }
 
     @Override
+    public Window setActiveWindow() {
+        assert _onUIThread();
+        _nSetForegroundWindow();
+        return this;
+    }
+
+    @Override
+    public Window setForegroundWindow() {
+        assert _onUIThread();
+        _nSetForegroundWindow();
+        return this;
+    }
+
+    @Override
     public ZOrder getZOrder() {
         assert _onUIThread();
         return ZOrder.NORMAL;
@@ -222,6 +236,8 @@ public class WindowWin32 extends Window {
     @ApiStatus.Internal public native void _nMinimize();
     @ApiStatus.Internal public native void _nRestore();
     @ApiStatus.Internal public native void _nFocus();
+    @ApiStatus.Internal public native void _nSetActiveWindow();
+    @ApiStatus.Internal public native void _nSetForegroundWindow();
     @ApiStatus.Internal public native void _nClose();
     @ApiStatus.Internal public native void _nWinSetParent(long hwnd);
 }

--- a/windows/java/WindowWin32.java
+++ b/windows/java/WindowWin32.java
@@ -166,43 +166,17 @@ public class WindowWin32 extends Window {
         return this;
     }
 
-    public Window setActiveWindow() {
+    @Override
+    public Window bringToFront() {
         assert _onUIThread();
-        _nSetForegroundWindow();
+        _nBringToFront();
         return this;
-    }
-
-    public long getForegroundWindow() {
-        assert _onUIThread();
-        return _nGetForegroundWindow();
-    }
-
-    public Window setForegroundWindow() {
-        assert _onUIThread();
-        _nSetForegroundWindow();
-        return this;
-    }
-
-    public long getCurrentThreadId() {
-        assert _onUIThread();
-        return _nGetCurrentThreadId();
-    }
-
-    public long attachThreadInput(long parentThreadId, long childThreadId, boolean attachOrDetach) {
-        assert _onUIThread();
-        return _nAttachThreadInput(parentThreadId, childThreadId, attachOrDetach);
-    }
-
-    public long getWindowThreadProcessId(long hWnd) {
-        assert _onUIThread();
-        return _nGetWindowThreadProcessId(hWnd);
     }
 
     @Override
-    public Window stealFocus() {
+    public boolean isFront() {
         assert _onUIThread();
-        _nStealFocus();
-        return this;
+        return _nIsFront();
     }
 
     @Override
@@ -261,13 +235,8 @@ public class WindowWin32 extends Window {
     @ApiStatus.Internal public native void _nMinimize();
     @ApiStatus.Internal public native void _nRestore();
     @ApiStatus.Internal public native void _nFocus();
-    @ApiStatus.Internal public native void _nSetActiveWindow();
-    @ApiStatus.Internal public native long _nGetForegroundWindow();
-    @ApiStatus.Internal public native void _nSetForegroundWindow();
-    @ApiStatus.Internal public native long _nGetCurrentThreadId();
-    @ApiStatus.Internal public native long _nGetWindowThreadProcessId(long hwnd);
-    @ApiStatus.Internal public native long _nAttachThreadInput(long parentThreadId, long childThreadId, boolean attachOrDetach);
-    @ApiStatus.Internal public native void _nStealFocus();
+    @ApiStatus.Internal public native void _nBringToFront();
+    @ApiStatus.Internal public native boolean _nIsFront();
     @ApiStatus.Internal public native void _nClose();
     @ApiStatus.Internal public native void _nWinSetParent(long hwnd);
 }


### PR DESCRIPTION
These are not sufficient to _steal_ foreground application focus in Windows, which will require another commit to add attaching the JWM window to the current foreground thread.

I'll mark this as Draft until subsequent commit but I wanted to open the floor for feedback on the first commit.

The subsequent commit will need to add functionality from the top answer of https://stackoverflow.com/questions/916259/win32-bring-a-window-to-top , which needs FNs for `GetForegroundWindow`, `GetCurrentThreadId`, `GetWindowThreadProcessId`, and `AttachThreadInput`. I'll first try just adding these to the `Window` class; there might be a better architecture to refactor this to, but I'll look to @tonsky's guidance once I actually get this working.