### PR TITLE
Add Mac bringToFront with NSApp activateIgnoringOtherApps

### DIFF
--- a/macos/cc/WindowMac.mm
+++ b/macos/cc/WindowMac.mm
@@ -525,8 +525,20 @@ extern "C" JNIEXPORT void JNICALL Java_io_github_humbleui_jwm_WindowMac__1nFocus
     [nsWindow makeKeyAndOrderFront:nil];
 }
 
-extern "C" JNIEXPORT jint JNICALL Java_io_github_humbleui_jwm_WindowMac__1nGetZOrder
+extern "C" JNIEXPORT bool JNICALL Java_io_github_humbleui_jwm_WindowMac__1nIsFront
   (JNIEnv* env, jobject obj) {
+    jwm::WindowMac* instance = reinterpret_cast<jwm::WindowMac*>(jwm::classes::Native::fromJava(env, obj));
+    NSWindow* nsWindow = instance->fNSWindow;
+    return [nsWindow isMainWindow];
+}
+
+extern "C" JNIEXPORT void JNICALL Java_io_github_humbleui_jwm_WindowMac__1nBringToFront
+  (JNIEnv* env, jobject obj) {
+    [NSApp activateIgnoringOtherApps:YES];
+}
+
+extern "C" JNIEXPORT jint JNICALL Java_io_github_humbleui_jwm_WindowMac__1nGetZOrder
+(JNIEnv* env, jobject obj) {
     jwm::WindowMac* instance = reinterpret_cast<jwm::WindowMac*>(jwm::classes::Native::fromJava(env, obj));
     NSWindow* nsWindow = instance->fNSWindow;
     NSWindowLevel level = [nsWindow level];

--- a/macos/java/WindowMac.java
+++ b/macos/java/WindowMac.java
@@ -251,15 +251,14 @@ public class WindowMac extends Window {
     @Override
     public Window bringToFront() {
         assert _onUIThread() : "Should be run on UI thread";
-        // TODO: impl me
+        _nBringToFront();
         return this;
     }
 
     @Override
     public boolean isFront() {
         assert _onUIThread() : "Should be run on UI thread";
-        // TODO: impl me
-        return false;
+        return _nIsFront();
     }
 
     @Override
@@ -315,6 +314,8 @@ public class WindowMac extends Window {
     @ApiStatus.Internal public native void _nHideMouseCursorUntilMoved(boolean value);
     @ApiStatus.Internal public native void _nLockMouseCursor(boolean value);
     @ApiStatus.Internal public native void _nSetVisible(boolean value);
+    @ApiStatus.Internal public native boolean _nIsFront();
+    @ApiStatus.Internal public native void _nBringToFront();
     @ApiStatus.Internal public native Screen _nGetScreen();
     @ApiStatus.Internal public native void _nRequestFrame();
     @ApiStatus.Internal public native void _nMinimize();


### PR DESCRIPTION
Also implement IsFront with NSWindow isMainWindow

Mac equivalent to PR #266, where these two functions work to get "launcher functionality" out of my HumbleUI program. I'm also still using JNativeHook to read Alt+Space from the user's keyboard while the launcher program is in the background & then forcing it to the front via `BringToFront()`

`IsFront()` is similarly used to determine whether the launcher is _already_ in the foreground so that the launcher can self-minimize.