### PR TITLE
Update Skija version and fix skija_native name for non-macOS

### DIFF
--- a/script/common.py
+++ b/script/common.py
@@ -8,7 +8,7 @@ def deps_compile():
   parser = argparse.ArgumentParser()
   parser.add_argument('--skija-dir', default=None)
   parser.add_argument('--skija-shared-jar', default=None)
-  parser.add_argument('--skija-version', default='0.109.2')
+  parser.add_argument('--skija-version', default='0.116.1')
   (args, _) = parser.parse_known_args()
 
   deps = [

--- a/script/run.py
+++ b/script/run.py
@@ -5,7 +5,7 @@ def main():
   parser = argparse.ArgumentParser()
   parser.add_argument('--example', default='dashboard')
   parser.add_argument('--jwm-version', default=None)
-  parser.add_argument('--skija-version', default='0.109.2')
+  parser.add_argument('--skija-version', default='0.116.1')
   parser.add_argument('--skija-dir', default=None)
   parser.add_argument('--skija-shared-jar', default=None)
   parser.add_argument('--skija-platform-jar', default=None)
@@ -46,7 +46,7 @@ def main():
       skija_platform_jar
     ]
   else:
-    skija_native = 'skija-' + build_utils.system + (('-' + build_utils.arch) if 'macos' == build_utils.system else '')
+    skija_native = 'skija-' + build_utils.system + '-' + build_utils.arch
     classpath += [
       build_utils.fetch_maven('io.github.humbleui', skija_native, args.skija_version),
     ]


### PR DESCRIPTION
Updates Skija to 0.116.1, and makes it use the e.g. `skija-linux-x64` repo path instead of `skija-linux`; that was broken for the previous 0.109.2 too actually.