### PR TITLE
Use XQueryPointer mouse position instead of XI_Motion fields

### DIFF
--- a/linux/cc/WindowManagerX11.cc
+++ b/linux/cc/WindowManagerX11.cc
@@ -410,15 +410,17 @@ void WindowManagerX11::_processXEvent(XEvent& ev) {
                             unsigned mask;
                             ::Window unused1;
                             int unused2;
-                            XQueryPointer(display, myWindow->_x11Window, &unused1, &unused1, &unused2, &unused2, &unused2, &unused2, &mask);
-                            lastMousePosX = deviceEvent->event_x;
-                            lastMousePosY = deviceEvent->event_y;
+                            int mouseCurrX, mouseCurrY;
+                            XQueryPointer(display, myWindow->_x11Window, &unused1, &unused1, &unused2, &unused2, &mouseCurrX, &mouseCurrY, &mask);
+
+                            lastMousePosX = mouseCurrX;
+                            lastMousePosY = mouseCurrY;
                             int movementX = 0, movementY = 0; // TODO: impl me!
                             jwm::JNILocal<jobject> eventMove(
                                 app.getJniEnv(),
                                 EventMouseMove::make(app.getJniEnv(),
-                                    deviceEvent->event_x,
-                                    deviceEvent->event_y,
+                                    mouseCurrX,
+                                    mouseCurrY,
                                     movementX,
                                     movementY,
                                     jwm::MouseButtonX11::fromNativeMask(mask),

--- a/linux/cc/WindowManagerX11.hh
+++ b/linux/cc/WindowManagerX11.hh
@@ -68,6 +68,7 @@ namespace jwm {
         std::atomic_bool notifyBool{false};
         int lastMousePosX = 0;
         int lastMousePosY = 0;
+        void mouseUpdate(WindowX11* myWindow);
 
         std::map<::Window, WindowX11*> _nativeWindowToMy;
         std::map<std::string, ByteBuf> _myClipboardContents;


### PR DESCRIPTION
Without this, on my system, the `XI_Motion` mouse events were always lagging one event behind (not just one frame, but from whenever was the last time the mouse moved, so the wrong mouse pointer could be kept indefinitely).

i.e., in this gif, whenever I'm moving the mouse back & forth a single pixel, the `XI_Motion:` logs show the previous position (i.e. moving one pixel right results in it the X coordinate decreasing).

![gif](https://github.com/HumbleUI/JWM/assets/5551338/5897fe91-8745-4ec5-baa7-e20a25b783c9)

The `XQueryPointer` values appear to be up-to-date always, however, so this patch switches to using them instead.

This effectively reduces the mouse→display latency by at least 1 frame or 16ms (which, though not the cause for me finding this, is definitely a good benefit!)