### PR TITLE
X11: add held modifier info on mouse events when window isn't focused

### DIFF
--- a/linux/cc/KeyX11.cc
+++ b/linux/cc/KeyX11.cc
@@ -28,6 +28,16 @@ int jwm::KeyX11::getModifiers() {
     return m;
 }
 
+int jwm::KeyX11::getModifiersFromMask(int mask) {
+    int m = getModifiers();
+
+    if (mask & ShiftMask  ) m |= (int)jwm::KeyModifier::SHIFT;
+    if (mask & ControlMask) m |= (int)jwm::KeyModifier::CONTROL;
+    if (mask & Mod1Mask   ) m |= (int)jwm::KeyModifier::ALT;
+
+    return m;
+}
+
 jwm::Key jwm::KeyX11::fromNative(uint32_t v) {
     switch (v) {
         // Modifiers

--- a/linux/cc/KeyX11.hh
+++ b/linux/cc/KeyX11.hh
@@ -9,5 +9,6 @@ namespace jwm {
         bool getKeyState(jwm::Key key);
         void setKeyState(jwm::Key key, bool isDown);
         int getModifiers();
+        int getModifiersFromMask(int mask);
     }
 }

--- a/linux/cc/WindowManagerX11.cc
+++ b/linux/cc/WindowManagerX11.cc
@@ -321,7 +321,7 @@ void WindowManagerX11::mouseUpdate(WindowX11* myWindow) {
             movementX,
             movementY,
             jwm::MouseButtonX11::fromNativeMask(mask),
-            jwm::KeyX11::getModifiers()
+            jwm::KeyX11::getModifiersFromMask(mask)
         )
     );
     myWindow->dispatch(eventMove.get());
@@ -430,7 +430,7 @@ void WindowManagerX11::_processXEvent(XEvent& ev) {
                                     0.0f,
                                     lastMousePosX,
                                     lastMousePosY,
-                                    jwm::KeyX11::getModifiers()
+                                    jwm::KeyX11::getModifiersFromMask(deviceEvent->mods.effective)
                                 )
                             );
                             myWindow->dispatch(eventMouseScroll.get());


### PR DESCRIPTION
Before this, moving the mouse or scrolling in JWM window while it isn't focused would always give no held modifiers. With this patch, the modifiers are read from the appropriate field in addition to the key state logic. (mouse/key presses don't need changes, as they only happen when the window is already focused)