### PR TITLE
X11: add KeyLocation, additional keys

### DIFF
--- a/linux/cc/KeyX11.cc
+++ b/linux/cc/KeyX11.cc
@@ -38,21 +38,23 @@ int jwm::KeyX11::getModifiersFromMask(int mask) {
     return m;
 }
 
-jwm::Key jwm::KeyX11::fromNative(uint32_t v) {
+jwm::Key jwm::KeyX11::fromNative(uint32_t v, jwm::KeyLocation& location, int& modifiers) {
+    location = jwm::KeyLocation::DEFAULT;
+    modifiers = 0;
     switch (v) {
         // Modifiers
         case XK_Caps_Lock: return Key::CAPS_LOCK;
-        case XK_Shift_R:
+        case XK_Shift_R: location = jwm::KeyLocation::RIGHT; // fallthrough
         case XK_Shift_L: return Key::SHIFT;
-        case XK_Control_R:
+        case XK_Control_R: location = jwm::KeyLocation::RIGHT; // fallthrough
         case XK_Control_L: return Key::CONTROL;
-        case XK_Alt_R:
+        case XK_Alt_R: location = jwm::KeyLocation::RIGHT; // fallthrough
         case XK_Alt_L: return Key::ALT;
         // Key::WIN_LOGO
-        case XK_Super_L:
-        case XK_Super_R: return Key::LINUX_SUPER;
-        case XK_Meta_L:
-        case XK_Meta_R: return Key::LINUX_META;
+        case XK_Super_R: location = jwm::KeyLocation::RIGHT; // fallthrough
+        case XK_Super_L: return Key::LINUX_SUPER;
+        case XK_Meta_R: location = jwm::KeyLocation::RIGHT; // fallthrough
+        case XK_Meta_L: return Key::LINUX_META;
         // Key::MAC_COMMAND
         // Key::MAC_OPTION
         // Key::MAC_FN
@@ -119,23 +121,25 @@ jwm::Key jwm::KeyX11::fromNative(uint32_t v) {
         case XK_bracketleft: return Key::OPEN_BRACKET;
         case XK_backslash: return Key::BACK_SLASH;
         case XK_bracketright: return Key::CLOSE_BRACKET;
-        case XK_KP_0: return Key::DIGIT0;
-        case XK_KP_1: return Key::DIGIT1;
-        case XK_KP_2: return Key::DIGIT2;
-        case XK_KP_3: return Key::DIGIT3;
-        case XK_KP_4: return Key::DIGIT4;
-        case XK_KP_5: return Key::DIGIT5;
-        case XK_KP_6: return Key::DIGIT6;
-        case XK_KP_7: return Key::DIGIT7;
-        case XK_KP_8: return Key::DIGIT8;
-        case XK_KP_9: return Key::DIGIT9;
+        case XK_KP_0: case XK_KP_Insert:    location = jwm::KeyLocation::KEYPAD; return Key::DIGIT0;
+        case XK_KP_1: case XK_KP_End:       location = jwm::KeyLocation::KEYPAD; return Key::DIGIT1;
+        case XK_KP_2: case XK_KP_Down:      location = jwm::KeyLocation::KEYPAD; return Key::DIGIT2;
+        case XK_KP_3: case XK_KP_Page_Down: location = jwm::KeyLocation::KEYPAD; return Key::DIGIT3;
+        case XK_KP_4: case XK_KP_Left:      location = jwm::KeyLocation::KEYPAD; return Key::DIGIT4;
+        case XK_KP_5: case XK_KP_Begin:     location = jwm::KeyLocation::KEYPAD; return Key::DIGIT5;
+        case XK_KP_6: case XK_KP_Right:     location = jwm::KeyLocation::KEYPAD; return Key::DIGIT6;
+        case XK_KP_7: case XK_KP_Home:      location = jwm::KeyLocation::KEYPAD; return Key::DIGIT7;
+        case XK_KP_8: case XK_KP_Up:        location = jwm::KeyLocation::KEYPAD; return Key::DIGIT8;
+        case XK_KP_9: case XK_KP_Page_Up:   location = jwm::KeyLocation::KEYPAD; return Key::DIGIT9;
+        case XK_KP_Add:       location = jwm::KeyLocation::KEYPAD; return Key::ADD;
+        case XK_KP_Separator: location = jwm::KeyLocation::KEYPAD; return Key::SEPARATOR;
+        case XK_KP_Subtract:  location = jwm::KeyLocation::KEYPAD; return Key::MINUS;
+        case XK_KP_Decimal:   location = jwm::KeyLocation::KEYPAD; return Key::PERIOD;
+        case XK_KP_Divide:    location = jwm::KeyLocation::KEYPAD; return Key::SLASH;
+        case XK_KP_Delete:    location = jwm::KeyLocation::KEYPAD; return Key::DEL;
+        case XK_KP_Enter:     location = jwm::KeyLocation::KEYPAD; return Key::ENTER;
+        case XK_KP_Multiply:  location = jwm::KeyLocation::KEYPAD; return Key::MULTIPLY;
         case XK_multiply: return Key::MULTIPLY;
-        case XK_KP_Add: return Key::ADD;
-        case XK_KP_Separator: return Key::SEPARATOR;
-        case XK_KP_Subtract: return Key::MINUS;
-        case XK_KP_Decimal: return Key::PERIOD;
-        case XK_KP_Divide: return Key::SLASH;
-        case XK_KP_Delete: return Key::DEL;
         case XK_Delete: return Key::DEL;
         case XK_Num_Lock: return Key::NUM_LOCK;
         case XK_Scroll_Lock: return Key::SCROLL_LOCK;
@@ -173,6 +177,53 @@ jwm::Key jwm::KeyX11::fromNative(uint32_t v) {
         // Key::VOLUME_UP
         // Key::VOLUME_DOWN
         // Key::MUTE
+        case XK_exclam:      modifiers = (int)jwm::KeyModifier::SHIFT; return Key::DIGIT1;
+        case XK_quotedbl:    modifiers = (int)jwm::KeyModifier::SHIFT; return Key::QUOTE;
+        case XK_numbersign:  modifiers = (int)jwm::KeyModifier::SHIFT; return Key::DIGIT3;
+        case XK_dollar:      modifiers = (int)jwm::KeyModifier::SHIFT; return Key::DIGIT4;
+        case XK_percent:     modifiers = (int)jwm::KeyModifier::SHIFT; return Key::DIGIT5;
+        case XK_ampersand:   modifiers = (int)jwm::KeyModifier::SHIFT; return Key::DIGIT7;
+        case XK_parenleft:   modifiers = (int)jwm::KeyModifier::SHIFT; return Key::DIGIT9;
+        case XK_parenright:  modifiers = (int)jwm::KeyModifier::SHIFT; return Key::DIGIT0;
+        case XK_asterisk:    modifiers = (int)jwm::KeyModifier::SHIFT; return Key::DIGIT8;
+        case XK_plus:        return Key::ADD;
+        case XK_colon:       modifiers = (int)jwm::KeyModifier::SHIFT; return Key::SEMICOLON;
+        case XK_less:        modifiers = (int)jwm::KeyModifier::SHIFT; return Key::COMMA;
+        case XK_greater:     modifiers = (int)jwm::KeyModifier::SHIFT; return Key::PERIOD;
+        case XK_question:    modifiers = (int)jwm::KeyModifier::SHIFT; return Key::SLASH;
+        case XK_at:          modifiers = (int)jwm::KeyModifier::SHIFT; return Key::DIGIT2;
+        case XK_asciicircum: modifiers = (int)jwm::KeyModifier::SHIFT; return Key::DIGIT6;
+        case XK_underscore:  modifiers = (int)jwm::KeyModifier::SHIFT; return Key::MINUS;
+        case XK_braceleft:   modifiers = (int)jwm::KeyModifier::SHIFT; return Key::OPEN_BRACKET;
+        case XK_bar:         modifiers = (int)jwm::KeyModifier::SHIFT; return Key::BACK_SLASH;
+        case XK_braceright:  modifiers = (int)jwm::KeyModifier::SHIFT; return Key::CLOSE_BRACKET;
+        case XK_asciitilde:  modifiers = (int)jwm::KeyModifier::SHIFT; return Key::BACK_QUOTE;
+        case XK_A: return Key::A;
+        case XK_B: return Key::B;
+        case XK_C: return Key::C;
+        case XK_D: return Key::D;
+        case XK_E: return Key::E;
+        case XK_F: return Key::F;
+        case XK_G: return Key::G;
+        case XK_H: return Key::H;
+        case XK_I: return Key::I;
+        case XK_J: return Key::J;
+        case XK_K: return Key::K;
+        case XK_L: return Key::L;
+        case XK_M: return Key::M;
+        case XK_N: return Key::N;
+        case XK_O: return Key::O;
+        case XK_P: return Key::P;
+        case XK_Q: return Key::Q;
+        case XK_R: return Key::R;
+        case XK_S: return Key::S;
+        case XK_T: return Key::T;
+        case XK_U: return Key::U;
+        case XK_V: return Key::V;
+        case XK_W: return Key::W;
+        case XK_X: return Key::X;
+        case XK_Y: return Key::Y;
+        case XK_Z: return Key::Z;
         default: return Key::UNDEFINED;
     }
 }

--- a/linux/cc/KeyX11.hh
+++ b/linux/cc/KeyX11.hh
@@ -2,10 +2,11 @@
 
 #include <cstdint>
 #include "Key.hh"
+#include "KeyLocation.hh"
 
 namespace jwm {
     namespace KeyX11 {
-        jwm::Key fromNative(uint32_t v);
+        jwm::Key fromNative(uint32_t v, jwm::KeyLocation& location, int& modifiers);
         bool getKeyState(jwm::Key key);
         void setKeyState(jwm::Key key, bool isDown);
         int getModifiers();

--- a/linux/cc/WindowManagerX11.cc
+++ b/linux/cc/WindowManagerX11.cc
@@ -588,13 +588,16 @@ void WindowManagerX11::_processXEvent(XEvent& ev) {
 
             KeySym s = XLookupKeysym(&ev.xkey, 0);
             if (s != NoSymbol) {
-                jwm::Key key = KeyX11::fromNative(s);
+                int modifiers;
+                jwm::KeyLocation location;
+                jwm::Key key = KeyX11::fromNative(s, location, modifiers);
                 jwm::KeyX11::setKeyState(key, true);
                 jwm::JNILocal<jobject> eventKey(app.getJniEnv(),
                                                         EventKey::make(app.getJniEnv(),
                                                                             key,
                                                                             true,
-                                                                            jwm::KeyX11::getModifiers()));
+                                                                            jwm::KeyX11::getModifiers() | modifiers,
+                                                                            location));
                 myWindow->dispatch(eventKey.get());
             }
 
@@ -630,13 +633,16 @@ void WindowManagerX11::_processXEvent(XEvent& ev) {
 
         case KeyRelease: { // keyboard up
             KeySym s = XLookupKeysym(&ev.xkey, 0);
-            jwm::Key key = KeyX11::fromNative(s);
+            int modifiers;
+            jwm::KeyLocation location;
+            jwm::Key key = KeyX11::fromNative(s, location, modifiers);
             jwm::KeyX11::setKeyState(key, false);
             jwm::JNILocal<jobject> eventKey(app.getJniEnv(),
                                                     EventKey::make(app.getJniEnv(),
                                                                         key,
                                                                         false,
-                                                                        jwm::KeyX11::getModifiers()));
+                                                                        jwm::KeyX11::getModifiers() | modifiers,
+                                                                        location));
             myWindow->dispatch(eventKey.get());
             break;
         }


### PR DESCRIPTION
Adds KeyLocation for right keys & keypad, and also adds additional Latin 1 keys mapping to shift+another key (not sure if all are strictly necessary, but it can't hurt; started by someone on a Faroese layout (`setxkbmap fo`) hitting `XK_plus` and I just added the rest from the latin-1 section).

The "shift+" part isn't particularly nice as then it's impossible to determine whether the actual shift key is pressed, but it's better than nothing.