### PR TITLE
fix resize frame

### DIFF
--- a/shared/java/Window.java
+++ b/shared/java/Window.java
@@ -423,7 +423,7 @@ public abstract class Window extends RefCounted implements Consumer<Event> {
         if (e instanceof EventWindowScreenChange) {
             accept(new EventWindowResize(this));
         } else if (e instanceof EventWindowResize && Platform.CURRENT != Platform.X11) {
-            accept(EventFrame.INSTANCE);
+            requestFrame();
         }
     }
 


### PR DESCRIPTION
Resizing doesn't correctly request a new frame. This changes the code so it goes through the platform specific way of requesting a new frame, instead of just accepting a frame event. Fixes resizing oddities in X11 (and wayland when the patch is applied to my branch).