### PR TITLE
X11: fix _nSetTitle return type

### DIFF
--- a/linux/java/WindowX11.java
+++ b/linux/java/WindowX11.java
@@ -225,7 +225,7 @@ public class WindowX11 extends Window {
     @ApiStatus.Internal public native void _nMaximize();
     @ApiStatus.Internal public native void _nMinimize();
     @ApiStatus.Internal public native void _nRestore();
-    @ApiStatus.Internal public native Screen _nSetTitle(byte[] title);
+    @ApiStatus.Internal public native void _nSetTitle(byte[] title);
     @ApiStatus.Internal public native void _nSetTitlebarVisible(boolean isVisible);
     @ApiStatus.Internal public native void _nSetFullScreen(boolean isFullScreen);
     @ApiStatus.Internal public native boolean _nIsFullScreen();


### PR DESCRIPTION
Fixes spurious errors, as the C function has a void return type, thus leaving garbage where JNI expects an object reference. Caused weird NPEs with clang++ 18 on titles longer than 23 chars.