### PR TITLE
X11: setIconData and setClassHint

### DIFF
--- a/examples/dashboard/java/Example.java
+++ b/examples/dashboard/java/Example.java
@@ -10,6 +10,9 @@ import java.util.concurrent.*;
 import java.util.function.*;
 import java.util.stream.*;
 import java.io.File;
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
 
 public class Example implements Consumer<Event> {
     public static int PADDING = 10;
@@ -81,6 +84,17 @@ public class Example implements Consumer<Event> {
             }
             case MACOS -> {
                 window.setIcon(new File("examples/dashboard/resources/macos.icns"));
+            }
+            case X11 -> {
+                ((WindowX11) window).setClassHint("jwm-dashboard-example"); // allows OS-wide identification of the window (e.g. icon themes, .desktop files)
+                try {
+                    Bitmap i = Bitmap.makeFromImage(Image.makeDeferredFromEncodedBytes(Files.readAllBytes(Path.of("examples/dashboard/resources/linux/icon_48x48.png"))));
+                    ImageInfo info = i.getImageInfo();
+
+                    ((WindowX11) window).setIconData(info.getWidth(), info.getHeight(), i.readPixels());
+                } catch (IOException e) {
+                    e.printStackTrace();
+                }
             }
         }
 

--- a/linux/cc/WindowManagerX11.hh
+++ b/linux/cc/WindowManagerX11.hh
@@ -121,6 +121,7 @@ namespace jwm {
             DEFINE_ATOM(_MOTIF_WM_HINTS);
             DEFINE_ATOM(_NET_WM_STATE);
             DEFINE_ATOM(_NET_WM_NAME);
+            DEFINE_ATOM(_NET_WM_ICON);
             DEFINE_ATOM(_NET_WM_STATE_MAXIMIZED_VERT);
             DEFINE_ATOM(_NET_WM_STATE_MAXIMIZED_HORZ);
             DEFINE_ATOM(_NET_FRAME_EXTENTS);

--- a/linux/cc/WindowX11.cc
+++ b/linux/cc/WindowX11.cc
@@ -32,6 +32,16 @@ void WindowX11::setTitle(const std::string& title) {
                     title.length());
 }
 
+void WindowX11::setClass(const std::string& name, const std::string& appClass) {
+    XClassHint *classHint = XAllocClassHint();
+    if (classHint) {
+        classHint->res_name = const_cast<char*>(name.c_str());
+        classHint->res_class = const_cast<char*>(appClass.c_str());
+        XSetClassHint(_windowManager.getDisplay(), _x11Window, classHint);
+        XFree(classHint);
+    }
+}
+
 void WindowX11::setTitlebarVisible(bool isVisible) {
     MotifHints motifHints = {0};
 
@@ -555,15 +565,25 @@ extern "C" JNIEXPORT void JNICALL Java_io_github_humbleui_jwm_WindowX11__1nClose
     jwm::WindowX11* instance = reinterpret_cast<jwm::WindowX11*>(jwm::classes::Native::fromJava(env, obj));
     instance->close();
 }
+
+static std::string bytesToString(JNIEnv* env, jbyteArray arr) {
+    jbyte* bytes = env->GetByteArrayElements(arr, nullptr);
+    std::string res = { bytes, bytes + env->GetArrayLength(arr) };
+    env->ReleaseByteArrayElements(arr, bytes, 0);
+    return res;
+}
+
 extern "C" JNIEXPORT void JNICALL Java_io_github_humbleui_jwm_WindowX11__1nSetTitle
         (JNIEnv* env, jobject obj, jbyteArray title) {
     jwm::WindowX11* instance = reinterpret_cast<jwm::WindowX11*>(jwm::classes::Native::fromJava(env, obj));
+    instance->setTitle(bytesToString(env, title));
+}
 
-    jbyte* bytes = env->GetByteArrayElements(title, nullptr);
-    std::string titleS = { bytes, bytes + env->GetArrayLength(title) };
-    env->ReleaseByteArrayElements(title, bytes, 0);
+extern "C" JNIEXPORT void JNICALL Java_io_github_humbleui_jwm_WindowX11__1nSetClassHint
+        (JNIEnv* env, jobject obj, jbyteArray name, jbyteArray appClass) {
+    jwm::WindowX11* instance = reinterpret_cast<jwm::WindowX11*>(jwm::classes::Native::fromJava(env, obj));
 
-    instance->setTitle(titleS);
+    instance->setClass(bytesToString(env, name), bytesToString(env, appClass));
 }
 
 extern "C" JNIEXPORT void JNICALL Java_io_github_humbleui_jwm_WindowX11__1nSetTitlebarVisible

--- a/linux/cc/WindowX11.hh
+++ b/linux/cc/WindowX11.hh
@@ -39,6 +39,7 @@ namespace jwm {
         }
         void setTitle(const std::string& title);
         void setClass(const std::string& name, const std::string& class_);
+        void setIconData(int width, int height, const unsigned char* argb);
         void setTitlebarVisible(bool isVisible);
 
         void maximize();

--- a/linux/cc/WindowX11.hh
+++ b/linux/cc/WindowX11.hh
@@ -38,6 +38,7 @@ namespace jwm {
             return _isRedrawRequested;
         }
         void setTitle(const std::string& title);
+        void setClass(const std::string& name, const std::string& class_);
         void setTitlebarVisible(bool isVisible);
 
         void maximize();

--- a/linux/java/WindowX11.java
+++ b/linux/java/WindowX11.java
@@ -95,6 +95,24 @@ public class WindowX11 extends Window {
         return this;
     }
 
+    /**
+     * <p>Set window icon from raw image bytes.</p>
+     *
+     * <p>{@code data} must have a length of {@code width * height * 4}, representing per-pixel ARGB data.</p>
+     *
+     * @param width     icon width in pixels
+     * @param height    icon height in pixels
+     * @param data      icon image data
+     * @return          this
+     */
+    @NotNull @Contract("-> this")
+    public Window setIconData(int width, int height, byte[] data) {
+        assert _onUIThread() : "Should be run on UI thread";
+        assert data.length == width*height*4 : "Incorrect icon data array length";
+        _nSetIconData(width, height, data);
+        return this;
+    }
+
     @Override
     public Window setTitlebarVisible(boolean value) {
         _nSetTitlebarVisible(value);
@@ -246,6 +264,7 @@ public class WindowX11 extends Window {
     @ApiStatus.Internal public native void _nRestore();
     @ApiStatus.Internal public native void _nSetTitle(byte[] title);
     @ApiStatus.Internal public native void _nSetClassHint(byte[] name, byte[] appClass);
+    @ApiStatus.Internal public native void _nSetIconData(int width, int height, byte[] data);
     @ApiStatus.Internal public native void _nSetTitlebarVisible(boolean isVisible);
     @ApiStatus.Internal public native void _nSetFullScreen(boolean isFullScreen);
     @ApiStatus.Internal public native boolean _nIsFullScreen();

--- a/linux/java/WindowX11.java
+++ b/linux/java/WindowX11.java
@@ -76,6 +76,25 @@ public class WindowX11 extends Window {
         return this;
     }
 
+    /**
+     * <p>Set the WM_CLASS window property.</p>
+     *
+     * @param appClass  application class
+     * @return          this
+     */
+    public Window setClassHint(String appClass) {
+        setClassHint(appClass, appClass);
+        return this;
+    }
+
+    public Window setClassHint(String name, String appClass) {
+        assert _onUIThread() : "Should be run on UI thread";
+        try {
+            _nSetClassHint(name.getBytes("UTF-8"), appClass.getBytes("UTF-8"));
+        } catch (UnsupportedEncodingException ignored) {}
+        return this;
+    }
+
     @Override
     public Window setTitlebarVisible(boolean value) {
         _nSetTitlebarVisible(value);
@@ -226,6 +245,7 @@ public class WindowX11 extends Window {
     @ApiStatus.Internal public native void _nMinimize();
     @ApiStatus.Internal public native void _nRestore();
     @ApiStatus.Internal public native void _nSetTitle(byte[] title);
+    @ApiStatus.Internal public native void _nSetClassHint(byte[] name, byte[] appClass);
     @ApiStatus.Internal public native void _nSetTitlebarVisible(boolean isVisible);
     @ApiStatus.Internal public native void _nSetFullScreen(boolean isFullScreen);
     @ApiStatus.Internal public native boolean _nIsFullScreen();


### PR DESCRIPTION
Implements the X11 part of #135, along with `WM_CLASS` initialization; both only under `WindowX11` currently.