### PR TITLE
Fix macos build

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.9)
+cmake_minimum_required(VERSION 4.0)
 project(jwm-project LANGUAGES CXX)
 
 ####################################################################
@@ -14,6 +14,7 @@ if(APPLE)
     add_subdirectory(macos)
     message(STATUS "Configure macos platform module")
 endif()
+
 
 if (UNIX AND NOT APPLE)
     add_subdirectory(linux)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 4.0)
+cmake_minimum_required(VERSION 3.9)
 project(jwm-project LANGUAGES CXX)
 
 ####################################################################

--- a/macos/CMakeLists.txt
+++ b/macos/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 4.0)
+cmake_minimum_required(VERSION 3.9)
 project(jwm LANGUAGES CXX OBJC)
 set(CMAKE_CXX_STANDARD 14)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)

--- a/macos/CMakeLists.txt
+++ b/macos/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.9)
+cmake_minimum_required(VERSION 4.0)
 project(jwm LANGUAGES CXX OBJC)
 set(CMAKE_CXX_STANDARD 14)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)

--- a/shared/cc/StringUTF16.cc
+++ b/shared/cc/StringUTF16.cc
@@ -70,7 +70,7 @@ jwm::StringUTF16::StringUTF16(const uint32_t *str) {
 }
 
 jwm::JNILocal<jstring> jwm::StringUTF16::toJString(JNIEnv* env) const {
-    return jwm::JNILocal<jstring>(env, env->NewString((const jchar*)c_str(), static_cast<jsize>(length())));
+    return jwm::JNILocal<jstring>(env, env->NewString(reinterpret_cast<const jchar*>(c_str()), static_cast<jsize>(length())));
 }
 
 jwm::StringUTF16 jwm::StringUTF16::makeFromJString(JNIEnv* env, jstring js) {

--- a/shared/cc/StringUTF16.cc
+++ b/shared/cc/StringUTF16.cc
@@ -70,14 +70,16 @@ jwm::StringUTF16::StringUTF16(const uint32_t *str) {
 }
 
 jwm::JNILocal<jstring> jwm::StringUTF16::toJString(JNIEnv* env) const {
-    return jwm::JNILocal<jstring>(env, env->NewString(c_str(), static_cast<jsize>(length())));
+    return jwm::JNILocal<jstring>(env, env->NewString((const jchar*)c_str(), static_cast<jsize>(length())));
 }
 
 jwm::StringUTF16 jwm::StringUTF16::makeFromJString(JNIEnv* env, jstring js) {
     jwm::StringUTF16 result;
     jsize length = env->GetStringLength(js);
     const jchar* chars = env->GetStringChars(js, nullptr);
-    result = jwm::StringUTF16(chars, length);
+
+    const char16_t* signed_chars = (const char16_t*)(chars);
+    result = jwm::StringUTF16(signed_chars, length);
     env->ReleaseStringChars(js, chars);
     return result;
 }

--- a/shared/cc/StringUTF16.cc
+++ b/shared/cc/StringUTF16.cc
@@ -78,7 +78,7 @@ jwm::StringUTF16 jwm::StringUTF16::makeFromJString(JNIEnv* env, jstring js) {
     jsize length = env->GetStringLength(js);
     const jchar* chars = env->GetStringChars(js, nullptr);
 
-    const char16_t* signed_chars = (const char16_t*)(chars);
+    const char16_t* signed_chars = reinterpret_cast<const char16_t*>(chars);
     result = jwm::StringUTF16(signed_chars, length);
     env->ReleaseStringChars(js, chars);
     return result;

--- a/shared/cc/StringUTF16.hh
+++ b/shared/cc/StringUTF16.hh
@@ -10,9 +10,9 @@ namespace jwm
     /**
      * @brief std::string which uses jchar as a character type
      */
-    class StringUTF16: public std::basic_string<jchar> {
+    class StringUTF16: public std::basic_string<char16_t> {
     public:
-        using std::basic_string<jchar>::basic_string;
+        using std::basic_string<char16_t>::basic_string;
 
         /**
          * Constructs StringUTF16 from C style string.


### PR DESCRIPTION
`jchar` is an alias to unsigned char. And c++ std doesn't provide a `basic_string` specialisation for it anymore