### PR TITLE
Update run.py - fix typo that break download

### DIFF
--- a/script/run.py
+++ b/script/run.py
@@ -28,7 +28,7 @@ def main():
   
   if args.jwm_version:
     classpath += [
-      build_utils.fetch_maven('io.github.humbleui.jwm', 'jwm', args.jwm_version)
+      build_utils.fetch_maven('io.github.humbleui', 'jwm', args.jwm_version)
     ]
   else:
     classpath += [


### PR DESCRIPTION
./script/run.py --jwm-version v0.4.18

Breaks, trying to download "https://repo1.maven.org/maven2/io/github/humbleui/jwm/jwm/v0.4.18/jwm-v0.4.18.jar" which doesn't exists.

This commit fix this issue.