### PR TITLE
Don't reset DirectContext on LayerGLSkija resize

### DIFF
--- a/shared/java/skija/LayerGLSkija.java
+++ b/shared/java/skija/LayerGLSkija.java
@@ -65,14 +65,10 @@ public class LayerGLSkija extends LayerGL {
             _renderTarget.close();
             _renderTarget = null;
         }
-
         if (_directContext != null) {
-            // https://bugs.chromium.org/p/skia/issues/detail?id=12814
-            // _directContext.abandon();
-            _directContext.close();
-            _directContext = null;
+            _directContext.resetGLAll();
         }
-        
+
         super.resize(width, height);
     }
 


### PR DESCRIPTION
From what I can tell, fully reinitializing `DirectContext` is generally undesirable outside of extraordinary situations, and indeed the Metal and D3D12 backends do not do so. Doing that also kills all offscreen `Surface`s, forcing unnecessarily discarding & recreating them.

Marking this PR as a draft for now as I don't particularly know how sane the `_directContext.resetGLAll();` is (without it there are some graphical glitches), but it does work for the dashboard example and my programs on linux, and allows for me to preserve `Surface`s across resizing; will report tomorrow on Windows, don't have macos to test on.

(this whole thing was brought on by me using "is current surface equal to previous surface" as a test for whether I should recreate my offscreen surfaces, which I needed to do for Linux/GL, but the D3D12 backend creates a new surface on every frame not just resizes, making my programs unnecessarily-slow from recreating & redrawing everything on every frame)