### PR TITLE
add loading of jwm_arm64.dll for Windows Arm64

### DIFF
--- a/shared/java/impl/Library.java
+++ b/shared/java/impl/Library.java
@@ -41,7 +41,8 @@ public class Library {
             File library = _extract("/", file, tempDir);
             System.load(library.getAbsolutePath());
         } else if (Platform.CURRENT == Platform.WINDOWS) {
-            File library = _extract("/", "jwm_x64.dll", tempDir);
+            String file = "aarch64".equals(System.getProperty("os.arch")) ? "jwm_arm64.dll" : "jwm_x64.dll";
+            File library = _extract("/", file, tempDir);
             System.load(library.getAbsolutePath());
         } else if (Platform.CURRENT == Platform.X11) {
             File library = _extract("/", "libjwm_x64.so", tempDir);


### PR DESCRIPTION
...so that JWM would work on Windows Arm64 platform.

With this fix, the `dashboard` example would work in Windows Arm64; here's its screenshot:

<img width="946" height="533" alt="Screenshot-arm64" src="https://github.com/user-attachments/assets/db179f1f-5d0e-4036-87b5-0466759a8056" />

For comparison, here's the screenshot of the same example in Windows x64:

<img width="946" height="509" alt="Screenshot-x64" src="https://github.com/user-attachments/assets/29f0f87e-adef-4d74-822e-b6ca896c1422" />
