### PR TITLE
support build for Linux Arm64

### DIFF
--- a/.github/workflows/build-deploy.yml
+++ b/.github/workflows/build-deploy.yml
@@ -28,6 +28,23 @@ jobs:
           name: native-linux
           path: linux/build/libjwm_x64.so
 
+  build_linux_arm64:
+    runs-on: ubuntu-24.04-arm
+    steps:
+      - uses: actions/checkout@v6
+      - uses: actions/setup-java@v5
+        with:
+          distribution: 'temurin'
+          java-version: '21'
+      - run: |
+          sudo apt update
+          sudo apt install -y mesa-common-dev libgl1-mesa-dev libx11-dev libxcursor-dev libxi-dev libxrandr-dev
+      - run: python3 script/build.py --only native
+      - uses: actions/upload-artifact@v7
+        with:
+          name: native-linux-arm64
+          path: linux/build/libjwm_arm64.so
+
   build_windows:
     strategy:
       matrix:

--- a/linux/CMakeLists.txt
+++ b/linux/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.9)
+cmake_minimum_required(VERSION 3.10)
 
 # prefer the newer GL library (GLVND)
 cmake_policy(SET CMP0072 NEW)

--- a/script/build.py
+++ b/script/build.py
@@ -20,6 +20,9 @@ def build_native():
   if os.path.exists('build/libjwm_x64.so'):
     build_utils.copy_newer('build/libjwm_x64.so', '../target/classes/libjwm_x64.so')
   
+  if os.path.exists('build/libjwm_arm64.so'):
+    build_utils.copy_newer('build/libjwm_arm64.so', '../target/classes/libjwm_arm64.so')
+
   if os.path.exists('build/jwm_x64.dll'):
     build_utils.copy_newer('build/jwm_x64.dll', '../target/classes/jwm_x64.dll')
 


### PR DESCRIPTION
Adding build job for Linux Arm64 platform in the GitHub workflow `build-deploy.yml`.

With this update, the `dashboard` example can be run on a Linux Arm64 box:

<img width="963" height="567" alt="Screenshot 2026-06-15 163208" src="https://github.com/user-attachments/assets/0c436ea8-50aa-4ee4-b7d1-046c08d2458b" />
