### PR TITLE
make examples more flexible

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,3 +14,6 @@ docs/apidocs
 
 # jvm crash logs
 hs_err_*.log
+
+# Gradle
+.gradle

--- a/examples/dashboard/java/Example.java
+++ b/examples/dashboard/java/Example.java
@@ -11,6 +11,7 @@ import java.util.function.*;
 import java.util.stream.*;
 import java.io.File;
 import java.io.IOException;
+import java.net.URISyntaxException;
 import java.nio.file.Files;
 import java.nio.file.Path;
 
@@ -78,17 +79,26 @@ public class Example implements Consumer<Event> {
             case 4 -> window.setWindowPosition(bounds.getLeft() + bounds.getWidth() / 2, bounds.getTop() + bounds.getHeight() / 2);
         }
 
+        var classLoader = getClass().getClassLoader();
         switch (Platform.CURRENT) {
             case WINDOWS -> {
-                window.setIcon(new File("examples/dashboard/resources/windows.ico"));
+                try {
+                    window.setIcon(new File(classLoader.getResource("windows.ico").toURI()));
+                } catch (URISyntaxException e) {
+                    e.printStackTrace();
+                }
             }
             case MACOS -> {
-                window.setIcon(new File("examples/dashboard/resources/macos.icns"));
+                try {
+                    window.setIcon(new File(classLoader.getResource("macos.icns").toURI()));
+                } catch (URISyntaxException e) {
+                    e.printStackTrace();
+                }
             }
             case X11 -> {
                 ((WindowX11) window).setClassHint("jwm-dashboard-example"); // allows OS-wide identification of the window (e.g. icon themes, .desktop files)
-                try {
-                    Bitmap i = Bitmap.makeFromImage(Image.makeDeferredFromEncodedBytes(Files.readAllBytes(Path.of("examples/dashboard/resources/linux/icon_48x48.png"))));
+                try (var in = classLoader.getResourceAsStream("linux/icon_48x48.png")) {
+                    Bitmap i = Bitmap.makeFromImage(Image.makeDeferredFromEncodedBytes(in.readAllBytes()));
                     ImageInfo info = i.getImageInfo();
 
                     ((WindowX11) window).setIconData(info.getWidth(), info.getHeight(), i.readPixels());

--- a/examples/empty/java/Example.java
+++ b/examples/empty/java/Example.java
@@ -15,7 +15,11 @@ public class Example implements Consumer<Event> {
         window = App.makeWindow();
         window.setEventListener(this);
         window.setTitle("Empty");
-        window.setLayer(new LayerGLSkija());
+        try {
+            window.setLayer(new LayerGLSkija());
+        } catch (Throwable e) {
+            window.setLayer(new LayerRasterSkija());
+        }
 
         var screen = App.getPrimaryScreen();
         var scale = screen.getScale();

--- a/script/run.py
+++ b/script/run.py
@@ -50,6 +50,11 @@ def main():
     classpath += [
       build_utils.fetch_maven('io.github.humbleui', skija_native, args.skija_version),
     ]
+  if args.example == 'dashboard':
+    # add dashboard resources to the classpath
+    classpath += [
+      'examples/dashboard/resources'
+    ]
   sources = build_utils.files(f'examples/{args.example}/java/**/*.java')
   build_utils.javac(sources, f'examples/{args.example}/target/classes', classpath = classpath, release='16')
   


### PR DESCRIPTION
- `dashboard` example: avoid hard-coded paths to its specific resources; instead, the resources can be found from the classpath.
- `empty` example: fall back to `LayerRasterSkija` layer, if the (default) `LayerGLSkija` settings have issues at runtime.
