### PR TITLE
Gradle build scripts for "empty" example application

### DIFF
--- a/examples/empty-native/README.md
+++ b/examples/empty-native/README.md
@@ -1,0 +1,74 @@
+# Gradle build scripts  for `empty` example application
+
+This directory contains Gradle scripts to build the `empty` example application,
+especially to produce a native image of the application using the
+[GraalVM](https://www.graalvm.org/latest/reference-manual/native-image/) tool.
+
+The scripts assume you already have the [Gradle](https://gradle.org/releases/) build tool
+installed and is available in the path. Standard Gradle commands can then be used to build the
+`empty` application, such as:
+
+* `gradle run`: compile and run the application
+* `gradle jar`: generate the application's `jar` file in `build/libs/` directory
+* etc.
+
+By default, the locally-compiled JWM classes are used as dependencies to compile the `empty`
+application. To use a published JWM version in Maven repository, specify the `-PjwmVersion=...`
+option in the Gradle commands, e.g.
+
+* `gradle run -PjwmVersion=0.4.25`: compile and run the application with JWM `0.4.25` version
+  published in Maven repository
+* etc.
+
+All of the above build commands would work on all platforms supported by JWM.
+
+Especially the scripts make use of the latest
+[Gradle native image](https://graalvm.github.io/native-build-tools/latest/gradle-plugin.html)
+plugin to generate the `empty-native` executable for current platform, as detailed below.
+
+## Building `empty` native image
+
+### Prerequisites
+
+A GraalVM JDK 25+ distribution is required to be installed and is available in the system, 
+e.g. from [Oracle](https://www.graalvm.org/downloads/) release, or from a
+[GraalVM Community](https://github.com/graalvm/graalvm-ce-builds/releases) distribution
+or from a [Liberica Native Image Kit](https://bell-sw.com/liberica-native-image-kit/) release,
+with the JAVA_HOME environment variable pointing to the installation and its `bin` directory be
+added to the path. More detailed installing info for various OSes is
+[here](https://www.graalvm.org/latest/getting-started/#installing).
+
+A C compiler for the current platform is also required to produce the native image executable.
+Detailed setup info is available [here](https://www.graalvm.org/latest/reference-manual/native-image/#prerequisites).
+
+### Building native image
+
+First, the
+[native image metadata](https://www.graalvm.org/latest/reference-manual/native-image/metadata/AutomaticMetadataCollection/)
+for the `empty` application need be generated, by running the application with the `-Pagent` option:
+```
+gradle run -Pagent
+```
+Use and interact with the running `empty` application as per normal, then close it.
+
+Then generate its native image with the command:
+```
+gradle nativeCompile
+```
+The resulting native image will be produced in the `build/native/nativeCompile/` directory,
+and can be executed directly:
+```
+./build/native/nativeCompile/empty-native
+```
+or in Windows:
+```
+build\native\nativeCompile\empty-native.exe
+```
+
+### Supported platforms
+
+The `empty` native images can be produced on platforms supported by GraalVM, namely:
+
+- Linux `x64/arm64`,
+- MacOS `x64/arm64` (but the `x64` support is removed in GraalVM 25.0.2+),
+- Windows `x64`.

--- a/examples/empty-native/build.gradle
+++ b/examples/empty-native/build.gradle
@@ -1,0 +1,113 @@
+plugins {
+    id 'application'
+    id 'com.google.osdetector' version '1.7.3'
+    id 'org.graalvm.buildtools.native' version '1.1.2'
+}
+
+group = 'io.github.humbleui.jwm'
+description = 'Native-image for JWM "empty" example'
+version = '1.0'
+
+// returns the [<os>, <arch>] platform pair suitable for retrieval
+// of Skija native dependencies of the current build platform
+def getCurrentPlatform() {
+    def os = osdetector.os
+    def skijaOS = switch (os) {
+        case 'linux' -> 'linux'
+        case 'osx' -> 'macos'
+        case 'windows' -> 'windows'
+        default -> 'unknown'
+    }
+    if (skijaOS == 'unknown')
+        throw new GradleException('Unsupported OS: ' + os)
+
+    def arch = osdetector.arch
+    //consider 64-bit architectures only
+    def skijaArch = switch (arch) {
+        case 'x86_64' -> 'x64'
+        case 'aarch_64' -> 'arm64'
+        default -> 'unknown'
+    }
+    if (skijaArch == 'unknown')
+        throw new GradleException('Unsupported Architecture: ' + arch)
+
+    return [skijaOS, skijaArch]
+}
+
+ext {
+    mainClassName = 'io.github.humbleui.jwm.examples.Example'
+    jwmVersion = project.properties['jwmVersion'] ?: 'None'
+    skijaVersion = '0.143.17'
+    (currentOS, currentArch) = getCurrentPlatform()
+}
+
+compileJava {
+    options.release = 25
+    options.encoding = 'UTF-8'
+}
+
+repositories {
+    mavenCentral()
+    mavenLocal()
+}
+
+dependencies {
+    implementation "io.github.humbleui:skija-$currentOS-$currentArch:$skijaVersion"
+    if (jwmVersion == 'None')
+        // use locally-compiled JWM classes
+        implementation files('../../target/classes')
+    else
+        // use published JWM version in Maven repository
+        implementation "io.github.humbleui:jwm:$jwmVersion"
+}
+
+sourceSets {
+    main {
+        java {
+            // source code of the "empty" example
+            srcDirs = ['../empty/java']
+        }
+    }
+}
+
+application {
+    mainClass = project.mainClassName
+    applicationName = project.name
+}
+
+graalvmNative {
+    def agentOutputDir = "$buildDir/native/agent-output/run"
+
+    toolchainDetection = false
+    binaries {
+        main {
+            imageName = project.name
+            mainClass = project.mainClassName
+            debug = true
+            verbose = true
+            fallback = false
+            sharedLibrary = false
+            configurationFileDirectories.from(file(agentOutputDir))
+
+            buildArgs.add('--enable-native-access=ALL-UNNAMED')
+            buildArgs.add('-march=compatibility')
+
+            useFatJar = false
+        }
+        all {
+            resources.autodetect()
+        }
+    }
+    agent {
+        defaultMode = 'standard'
+        enabled = false
+
+        modes {
+            standard {
+            }
+            direct {
+                options.add("config-output-dir=$agentOutputDir")
+            }
+        }
+    }
+}

--- a/examples/empty-native/settings.gradle
+++ b/examples/empty-native/settings.gradle
@@ -1,0 +1,1 @@
+rootProject.name = 'empty-native'


### PR DESCRIPTION
... especially to produce "empty" native image by GraalVM.

Caveat: I haven't tested it on Mac platforms. Please try it on a Mac to see if it works.

Below is the `README.md` text:

# Gradle build scripts  for `empty` example application

This directory contains Gradle scripts to build the `empty` example application, especially to produce a native image of the application using the [GraalVM](https://www.graalvm.org/latest/reference-manual/native-image/) tool.

The scripts assume you already have the [Gradle](https://gradle.org/releases/) build tool installed and is available in the path. Standard Gradle commands can then be used to build the `empty` application, such as:

* `gradle run`: compile and run the application
* `gradle jar`: generate the application's `jar` file in `build/libs/` directory
* etc.

By default, the locally-compiled JWM classes are used as dependencies to compile the `empty` application. To use a published JWM version in Maven repository, specify the `-PjwmVersion=...` option in the Gradle commands, e.g.

* `gradle run -PjwmVersion=0.4.25`: compile and run the application with JWM `0.4.25` version published in Maven repository
* etc.

All of the above build commands would work on all platforms supported by JWM.

Especially the scripts make use of the latest [Gradle native image](https://graalvm.github.io/native-build-tools/latest/gradle-plugin.html) plugin to generate the `empty-native` executable for current platform, as detailed below.

## Building `empty` native image

### Prerequisites

A GraalVM JDK 25+ distribution is required to be installed and is available in the system, e.g. from [Oracle](https://www.graalvm.org/downloads/) release, or from a [GraalVM Community](https://github.com/graalvm/graalvm-ce-builds/releases) distribution or from a [Liberica Native Image Kit](https://bell-sw.com/liberica-native-image-kit/) release, with the JAVA_HOME environment variable pointing to the installation and its `bin` directory be added to the path. More detailed installing info for various OSes is [here](https://www.graalvm.org/latest/getting-started/#installing).

A C compiler for the current platform is also required to produce the native image executable. Detailed setup info is available [here](https://www.graalvm.org/latest/reference-manual/native-image/#prerequisites).

### Building native image

First, the [native image metadata](https://www.graalvm.org/latest/reference-manual/native-image/metadata/AutomaticMetadataCollection/) for the `empty` application need be generated, by running the application with the `-Pagent` option:
```
gradle run -Pagent
```
Use and interact with the running `empty` application as per normal, then close it.

Then generate its native image with the command:
```
gradle nativeCompile
```
The resulting native image will be produced in the `build/native/nativeCompile/` directory, and can be executed directly:
```
./build/native/nativeCompile/empty-native
```
or in Windows:
```
build\native\nativeCompile\empty-native.exe
```

### Supported platforms

The `empty` native images can be produced on platforms supported by GraalVM, namely:

- Linux `x64/arm64`,
- MacOS `x64/arm64` (but the `x64` support is removed in GraalVM 25.0.2+),
- Windows `x64`.
