### PR TITLE
Add Window::setParentWindow (macOS child windows)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 # WIP
 
+- Added `Window::setParentWindow` (macOS only for now): attach a window as a child of another, keeping it above its parent without floating above other applications
 - Bumped types in pom.xml to 0.2.0
 - Windows, Linux: Window::setIconPixels (previously setIconData on Linux) #310 #135 via @chirontt 
 - macOS: fixed incorrect app shutdown

--- a/README.md
+++ b/README.md
@@ -135,6 +135,7 @@ Alpha. Expect API breakages.
 | setResizable        | ❌   | ❌   | ❌   |
 | bringToFront        | ✅   | ❌   | ❌   |
 | isFront             | ✅   | ✅   | ❌   |
+| setParentWindow     | ❌   | ✅   | ❌   |
 
 ### Events
 

--- a/linux/java/WindowX11.java
+++ b/linux/java/WindowX11.java
@@ -221,6 +221,13 @@ public class WindowX11 extends Window {
     }
 
     @Override
+    public Window setParentWindow(Window parent) {
+        assert _onUIThread() : "Should be run on UI thread";
+        // TODO implement (XSetTransientForHint)
+        return this;
+    }
+
+    @Override
     public float getProgressBar() {
         throw new UnsupportedOperationException("impl me!");
     }

--- a/macos/cc/WindowMac.mm
+++ b/macos/cc/WindowMac.mm
@@ -600,6 +600,18 @@ extern "C" JNIEXPORT void JNICALL Java_io_github_humbleui_jwm_WindowMac__1nSetZO
     nsWindow.level = level;
 }
 
+extern "C" JNIEXPORT void JNICALL Java_io_github_humbleui_jwm_WindowMac__1nSetParentWindow
+  (JNIEnv* env, jobject obj, jlong parentPtr) {
+    jwm::WindowMac* instance = reinterpret_cast<jwm::WindowMac*>(jwm::classes::Native::fromJava(env, obj));
+    NSWindow* nsWindow = instance->fNSWindow;
+    if (nsWindow.parentWindow)
+        [nsWindow.parentWindow removeChildWindow:nsWindow];
+    if (parentPtr) {
+        jwm::WindowMac* parent = reinterpret_cast<jwm::WindowMac*>(static_cast<uintptr_t>(parentPtr));
+        [parent->fNSWindow addChildWindow:nsWindow ordered:NSWindowAbove];
+    }
+}
+
 extern "C" JNIEXPORT void JNICALL Java_io_github_humbleui_jwm_WindowMac__1nSetProgressBar
   (JNIEnv* env, jobject obj, jfloat value) {
     // Based on

--- a/macos/java/WindowMac.java
+++ b/macos/java/WindowMac.java
@@ -4,6 +4,7 @@ import java.io.*;
 import java.util.concurrent.*;
 import java.util.function.*;
 import org.jetbrains.annotations.*;
+import io.github.humbleui.jwm.impl.*;
 import io.github.humbleui.types.*;
 
 public class WindowMac extends Window {
@@ -281,6 +282,13 @@ public class WindowMac extends Window {
     }
 
     @Override
+    public Window setParentWindow(@Nullable Window parent) {
+        assert _onUIThread() : "Should be run on UI thread";
+        _nSetParentWindow(Native.getPtr(parent));
+        return this;
+    }
+
+    @Override
     public float getProgressBar() {
         assert _onUIThread() : "Should be run on UI thread";
         return _lastProgressBarValue;
@@ -366,6 +374,7 @@ public class WindowMac extends Window {
     @ApiStatus.Internal public native void _nFocus();
     @ApiStatus.Internal public native int _nGetZOrder();
     @ApiStatus.Internal public native void _nSetZOrder(int zOrder);
+    @ApiStatus.Internal public native void _nSetParentWindow(long parentPtr);
     @ApiStatus.Internal public native void _nSetProgressBar(float value);
     @ApiStatus.Internal public native void _nClose();
     @ApiStatus.Internal public native void _nSetPressAndHoldEnabled(boolean enabled);

--- a/shared/java/Window.java
+++ b/shared/java/Window.java
@@ -390,10 +390,28 @@ public abstract class Window extends RefCounted implements Consumer<Event> {
 
     /**
      * <p>Makes window float always on top.</p>
-     * 
+     *
      * @return  this
      */
     public abstract Window setZOrder(ZOrder order);
+
+    /**
+     * <p>Attaches this window as a child of {@code parent}: it stays ordered above the
+     * parent window, but — unlike {@link #setZOrder(ZOrder)} with a floating level —
+     * does not float above other applications' windows. The child moves together with
+     * its parent.</p>
+     *
+     * <p>Pass {@code null} to detach. Attach after making this window visible: on macOS,
+     * attaching orders the window in, and hiding a child window detaches it
+     * automatically — so re-attach on every show.</p>
+     *
+     * <p>Currently implemented on macOS only ({@code addChildWindow:ordered:}); no-op on
+     * Windows and X11.</p>
+     *
+     * @param parent  window to attach to, or {@code null} to detach
+     * @return  this
+     */
+    public abstract Window setParentWindow(@Nullable Window parent);
 
     /**
      * @return The current progress bar value for this window

--- a/windows/java/WindowWin32.java
+++ b/windows/java/WindowWin32.java
@@ -212,6 +212,13 @@ public class WindowWin32 extends Window {
     }
 
     @Override
+    public Window setParentWindow(Window parent) {
+        assert _onUIThread() : "Should be run on UI thread";
+        // TODO implement (owner window via GWLP_HWNDPARENT; see winSetParent)
+        return this;
+    }
+
+    @Override
     public float getProgressBar() {
         throw new UnsupportedOperationException("impl me!");
     }


### PR DESCRIPTION
## What

New API `Window.setParentWindow(@Nullable Window parent)`, implemented on macOS via `-[NSWindow addChildWindow:ordered:]` (`NSWindowAbove`). A child window stays ordered above its parent **within the application** — unlike `setZOrder(FLOATING/MODAL_PANEL)`, it does not float above other applications' windows. Passing `null` detaches.

## Why

The floating `ZOrder` levels are global: a tool/palette window (robot consoles in my app's case) set to `FLOATING`/`MODAL_PANEL` stays above every other application too. Child windows are the native macOS mechanism for "always above one specific window only".

## Notes / caveats

- macOS semantics, documented in the javadoc: the child moves together with its parent, and hiding (orderOut) a child window detaches it automatically — callers should attach after `setVisible(true)` on every show.
- Windows/X11 are TODO stubs following the existing `setZOrder` stub style (Win32 could later reuse the `_nWinSetParent` owner-window plumbing; X11 via `XSetTransientForHint`).
- README feature matrix + CHANGELOG updated.
- Built and exercised on macOS arm64 from a downstream app consuming `target/classes`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)